### PR TITLE
Import dependency projects to demos folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 sudo apt update && sudo apt install upgrade -y
 mkdir ~/ws_pai/src -p && cd ~/ws_pai/src
 git clone https://github.com/ros-physical-ai/demos
-vcs import . < demos/pai.repos --recursive
+vcs import demos < demos/pai.repos --recursive
 cd ~/ws_pai
 rosdep install --from-paths src --ignore-src --rosdistro kilted -yir
 source /opt/ros/kilted/setup.bash


### PR DESCRIPTION
**Main changes**

Change vcs import folder to demos so that all dependencies fold under the demos folder. This facilitates the pixi dependency management [PR](https://github.com/ros-physical-ai/demos/pull/5); see [comments](https://github.com/ros-physical-ai/demos/pull/5#discussion_r2706817645) for details.

@sea-bass, @Yadunund, @vavu-huawei, please help review.