### PR TITLE
Removes lerobot from pi.repos

### DIFF
--- a/pai.repos
+++ b/pai.repos
@@ -7,7 +7,3 @@ repositories:
     type: git
     url: https://github.com/JafarAbdi/feetech_ros2_driver.git
     version: main
-  huggingface/lerobot:
-    type: git
-    url: https://github.com/huggingface/lerobot.git
-    version: v0.3.3


### PR DESCRIPTION
## Context

- After #11 lerobot is bumped to 0.4.3 and installed via pixi pypi.
- As of lerobot 0.4.X, utility scripts like `lerobot-train` , `lerobot-replay`, etc are installed so they can be used directly.

## Summary

 - This PR removes lerobot repository as it doesn't seem it is necessary anymore