### PR TITLE
fix(mujoco): resolve ros2_control_node init and controller activation

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ For instructions on training a policy and running inference see [this guide](./d
 ros2 launch pai_bringup so_arm_mujoco_bringup.launch.py
 ```
 
+With Pixi: `pixi run so-arm-mujoco`
+
 ## Pixi Development
 
 For a more isolated and reproducible development environment, we recommend using [Pixi](https://pixi.sh/). See [DEVELOPMENT.md](./docs/DEVELOPMENT.md) for the Pixi-based workflow.

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -68,6 +68,11 @@ Terminal 2 (launch Gazebo simulation):
 pixi run so-arm-gz
 ```
 
+MuJoCo simulation (SO-ARM in MuJoCo):
+```bash
+pixi run so-arm-mujoco
+```
+
 ### 4. Interactive Mode with Pixi Shell
 
 For interactive development, you can use `pixi shell` to enter an interactive shell with the environment activated.

--- a/docs/so_arm_demo.md
+++ b/docs/so_arm_demo.md
@@ -37,6 +37,23 @@ pip install torch==2.7.0+cu128 torchaudio==2.7.0+cu128 torchcodec==0.4.0 torchvi
 pip install lerobot==0.3.3
 ```
 
+Using Pixi (recommended for this repo)
+
+Pixi provides an isolated environment with ROS 2 Kilted and LeRobot. From the repo root:
+
+```bash
+# Install base environment (ROS 2 Kilted, colcon, etc.)
+pixi install
+
+# Install ML dependencies (detects RTX 5090 and installs PyTorch cu128)
+pixi run install-ml-deps
+
+# Build the workspace
+pixi run build
+```
+
+The `install-ml-deps` task detects your GPU and installs the appropriate PyTorch (e.g. cu128 for RTX 5090). See [DEVELOPMENT.md](DEVELOPMENT.md) for more details.
+
 #### Calibration
 
 ```bash

--- a/pai_bringup/config/ros2_control/so_arm_mujoco_controllers.yaml
+++ b/pai_bringup/config/ros2_control/so_arm_mujoco_controllers.yaml
@@ -1,0 +1,63 @@
+# Copyright (C) 2026 ros2_control Development Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Authors: Julia Jia
+#
+# MuJoCo controller config for SO-ARM101 (no prefix / single-robot)
+
+controller_manager:
+  ros__parameters:
+    update_rate: 50  # Hz
+
+    joint_trajectory_controller:
+      type: joint_trajectory_controller/JointTrajectoryController
+
+    joint_state_broadcaster:
+      type: joint_state_broadcaster/JointStateBroadcaster
+
+    forward_position_controller:
+      type: position_controllers/JointGroupPositionController
+
+    gripper_controller:
+      type: parallel_gripper_action_controller/GripperActionController
+
+
+gripper_controller:
+  ros__parameters:
+    joint: gripper_joint
+    allow_stalling: true
+
+
+joint_trajectory_controller:
+  ros__parameters:
+    command_interfaces:
+      - position
+    state_interfaces:
+      - position
+      - velocity
+    joints:
+      - shoulder_pan_joint
+      - shoulder_lift_joint
+      - elbow_flex_joint
+      - wrist_flex_joint
+      - wrist_roll_joint
+
+forward_position_controller:
+  ros__parameters:
+    joints:
+      - shoulder_pan_joint
+      - shoulder_lift_joint
+      - elbow_flex_joint
+      - wrist_flex_joint
+      - wrist_roll_joint

--- a/pai_bringup/launch/so_arm_mujoco_bringup.launch.py
+++ b/pai_bringup/launch/so_arm_mujoco_bringup.launch.py
@@ -25,11 +25,12 @@ def generate_launch_description():
             ),
         ]
     )
-
     robot_description = {"robot_description": ParameterValue(value=robot_description_content, value_type=str)}
 
     controller_parameters = ParameterFile(
-        PathJoinSubstitution([FindPackageShare("so_arm101_description"), "control", "ros2_controllers.yaml"]),
+        PathJoinSubstitution(
+            [FindPackageShare("pai_bringup"), "config", "ros2_control", "so_arm_mujoco_controllers.yaml"]
+        ),
     )
 
     robot_state_publisher_node = Node(

--- a/pai_bringup/mjcf/scene.xml
+++ b/pai_bringup/mjcf/scene.xml
@@ -1,24 +1,45 @@
-<mujoco model="scene">
-    <include file="so_arm101.xml" />
+<mujoco model="so_arm101 scene">
+  <include file="so_arm101.xml" />
 
-    <visual>
-        <headlight diffuse="0.6 0.6 0.6" ambient="0.3 0.3 0.3" specular="0 0 0" />
-        <rgba haze="0.15 0.25 0.35 1" />
-        <global azimuth="160" elevation="-20" />
-    </visual>
+  <statistic center="0.1 -0.01 0.05" extent="0.5" />
 
-    <asset>
-        <texture type="skybox" builtin="gradient" rgb1="0.3 0.5 0.7" rgb2="0 0 0" width="512"
-            height="3072" />
-        <texture type="2d" name="groundplane" builtin="checker" mark="edge" rgb1="0.2 0.3 0.4"
-            rgb2="0.1 0.2 0.3"
-            markrgb="0.8 0.8 0.8" width="300" height="300" />
-        <material name="groundplane" texture="groundplane" texuniform="true" texrepeat="5 5"
-            reflectance="0.2" />
-    </asset>
+  <visual>
+    <headlight diffuse="0.6 0.6 0.6" ambient="0.3 0.3 0.3" specular="0 0 0" />
+    <rgba haze="0.15 0.25 0.35 1" />
+    <global azimuth="45" elevation="-20" />
+  </visual>
 
-    <worldbody>
-        <light pos="0 0 3.5" dir="0 0 -1" directional="true" />
-        <geom name="floor" size="0 0 0.05" pos="0 0 0" type="plane" material="groundplane" />
-    </worldbody>
+  <asset>
+    <texture
+      type="skybox"
+      builtin="gradient"
+      rgb1="0.3 0.5 0.7"
+      rgb2="0 0 0"
+      width="512"
+      height="3072"
+    />
+    <texture
+      type="2d"
+      name="groundplane"
+      builtin="checker"
+      mark="edge"
+      rgb1="0.2 0.3 0.4"
+      rgb2="0.1 0.2 0.3"
+      markrgb="0.8 0.8 0.8"
+      width="300"
+      height="300"
+    />
+    <material
+      name="groundplane"
+      texture="groundplane"
+      texuniform="true"
+      texrepeat="5 5"
+      reflectance="0.2"
+    />
+  </asset>
+
+  <worldbody>
+    <light pos="0 0 1.5" dir="0 0 -1" directional="true" />
+    <geom name="floor" size="0 0 0.05" type="plane" material="groundplane" />
+  </worldbody>
 </mujoco>

--- a/pixi.lock
+++ b/pixi.lock
@@ -750,6 +750,7 @@ environments:
       - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-tl-expected-1.2.0-np2py312h2ed9cc7_15.conda
       - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-tracetools-8.6.0-np2py312h2ed9cc7_15.conda
       - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-trajectory-msgs-5.5.1-np2py312h2ed9cc7_15.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-transmission-interface-5.11.3-np2py312h2c89a96_15.conda
       - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-type-description-interfaces-2.3.0-np2py312h2ed9cc7_15.conda
       - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-uncrustify-vendor-3.1.0-np2py312h2ed9cc7_15.conda
       - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-unique-identifier-msgs-2.7.0-np2py312h2ed9cc7_15.conda
@@ -1673,6 +1674,7 @@ environments:
       - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-tl-expected-1.2.0-np2py312h61f2ce4_15.conda
       - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-tracetools-8.6.0-np2py312h61f2ce4_15.conda
       - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-trajectory-msgs-5.5.1-np2py312h61f2ce4_15.conda
+      - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-transmission-interface-5.11.3-np2py312h8b5252a_15.conda
       - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-type-description-interfaces-2.3.0-np2py312h61f2ce4_15.conda
       - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-uncrustify-vendor-3.1.0-np2py312h61f2ce4_15.conda
       - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-unique-identifier-msgs-2.7.0-np2py312h61f2ce4_15.conda
@@ -28410,6 +28412,46 @@ packages:
   license: Apache-2.0
   size: 151778
   timestamp: 1769483863964
+- conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-transmission-interface-5.11.3-np2py312h2c89a96_15.conda
+  sha256: 7dcad59a2f30bcf1adc9574d8167852cea06e6a7ee1cfd5acd4ee7bfc9940847
+  md5: 6c267cbed5e696e186dcb580076f6fd0
+  depends:
+  - fmt
+  - python
+  - ros-kilted-hardware-interface
+  - ros-kilted-pluginlib
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.13.* kilted_*
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - fmt >=12.1.0,<12.2.0a0
+  - numpy >=1.23,<3
+  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - python_abi 3.12.* *_cp312
+  license: Apache-2.0
+  size: 106765
+  timestamp: 1769486626456
+- conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-transmission-interface-5.11.3-np2py312h8b5252a_15.conda
+  sha256: bf13043b4813a69cf18a410a4e913f197683cf6dd3b1cacceac6afdb2a367990
+  md5: 97ef52f9401a4ca4637dd02e74280e91
+  depends:
+  - fmt
+  - python
+  - ros-kilted-hardware-interface
+  - ros-kilted-pluginlib
+  - ros-kilted-ros-workspace
+  - ros2-distro-mutex 0.13.* kilted_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.13.0,<0.14.0a0
+  - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
+  - fmt >=12.1.0,<12.2.0a0
+  license: Apache-2.0
+  size: 106372
+  timestamp: 1769486538262
 - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-type-description-interfaces-2.3.0-np2py312h2ed9cc7_15.conda
   sha256: 3f95072511a525047578375234c3294e68cf4cbda58f11399102fad56278f328
   md5: 06d29b78a2456161e1885c8f6a516027

--- a/pixi.toml
+++ b/pixi.toml
@@ -22,6 +22,7 @@ start_zenoh = { cmd = [
   "rmw_zenohd",
 ]}
 so-arm-gz = { cmd = ["ros2", "launch", "pai_bringup", "so_arm_gz_bringup.launch.py"] }
+so-arm-mujoco = { cmd = ["ros2", "launch", "pai_bringup", "so_arm_mujoco_bringup.launch.py"] }
 # Run LeRobot inference node
 # Note: policy_path defaults to 'outputs/train/act_move_to_cube/checkpoints/040000/pretrained_model'
 # Override it via: pixi run lerobot-inference --ros-args -p policy_path:=/path/to/your/model
@@ -105,6 +106,7 @@ ros-kilted-joint-trajectory-controller = "*"
 ros-kilted-parallel-gripper-controller = "*"
 ros-kilted-position-controllers = "*"
 ros-kilted-hardware-interface = "*"
+ros-kilted-transmission-interface = "*"
 ros-kilted-ament-index-python = "*"
 ros-kilted-nav2-common = "*"
 ros-kilted-gz-ros2-control = "*"


### PR DESCRIPTION
An add-on to https://github.com/ros-physical-ai/demos/pull/3

- Add transmission_interface dependency for SO-ARM101 transmissions
- Add so_arm_mujoco_controllers.yaml with resolved joint names
- Sync scene.xml with external SO-ARM100 source of truth
- Add so-arm-mujoco Pixi task and MuJoCo docs

Why so_arm_mujoco_controllers.yaml was added
- so_arm101_description/control/ros2_controllers.yaml uses the <robot_namespace> placeholder (e.g. <robot_namespace>shoulder_pan_joint). That placeholder is meant to be replaced at launch time  when using namespaces or prefixes.
- The MuJoCo launch does not seem to perform that replacement, so the controller_manager received literal strings like <robot_namespace>shoulder_pan_joint/position, which do not match the hardware interfaces (shoulder_pan_joint/position), causing activation failures.
```
[ERROR] [spawner-4]: process has died [pid 63239, exit code 1, cmd '/home/juliajia/ws_pai/src/demos/.pixi/envs/default/lib/controller_manager/spawner joint_trajectory_controller --ros-args -r __node:=spawn_joint_trajectory_controller'].
[spawner-5] [INFO] [1771293107.899934965] [spawn_gripper_controller]: Loaded gripper_controller
[ros2_control_node-2] [INFO] [1771293107.900271137] [controller_manager]: Configuring controller: 'gripper_controller'
[ros2_control_node-2] [INFO] [1771293107.900351747] [gripper_controller]: Action status changes will be monitored at 20.000000 Hz.
[ros2_control_node-2] [INFO] [1771293107.900359927] [gripper_controller]: Joint name is : <robot_namespace>gripper_joint
[ros2_control_node-2] [INFO] [1771293107.911625904] [controller_manager]: Activating controllers: [ gripper_controller ]
[ros2_control_node-2] [WARN] [1771293107.911644554] [controller_manager]: Unable to activate controller 'gripper_controller' since the command interface '<robot_namespace>gripper_joint/position' is not available.
[spawner-5] [ERROR] [1771293107.912033536] [spawn_gripper_controller]: Failed to activate controller : gripper_controller
[ERROR] [spawner-5]: process has died [pid 63241, exit code 1, cmd '/home/juliajia/ws_pai/src/demos/.pixi/envs/default/lib/controller_manager/spawner gripper_controller --ros-args -r __node:=spawn_gripper_controller'].

```
so_arm_mujoco_controllers.yaml was added as a MuJoCo-specific config with joint names already resolved (no prefix), so no runtime substitution is needed and the controllers activate correctly. 