### PR TITLE
MuJoCo sim + rosetta data collection

### DIFF
--- a/pai_bringup/CMakeLists.txt
+++ b/pai_bringup/CMakeLists.txt
@@ -17,6 +17,7 @@ install(
 install(
   PROGRAMS
     scripts/lerobot_inference_node
+    scripts/camera_relay_node
   DESTINATION lib/${PROJECT_NAME}
 )
 

--- a/pai_bringup/config/ros2_controllers_mujoco.yaml
+++ b/pai_bringup/config/ros2_controllers_mujoco.yaml
@@ -1,0 +1,43 @@
+# MuJoCo-specific controller config for LeRobot inference and rosetta data collection.
+# forward_position_controller with 6 joints (including gripper) for single-topic commands.
+controller_manager:
+  ros__parameters:
+    update_rate: 50
+
+    joint_trajectory_controller:
+      type: joint_trajectory_controller/JointTrajectoryController
+
+    joint_state_broadcaster:
+      type: joint_state_broadcaster/JointStateBroadcaster
+
+    forward_position_controller:
+      type: position_controllers/JointGroupPositionController
+
+    gripper_controller:
+      type: parallel_gripper_action_controller/GripperActionController
+
+gripper_controller:
+  ros__parameters:
+    joint: <robot_namespace>gripper_joint
+    allow_stalling: true
+
+joint_trajectory_controller:
+  ros__parameters:
+    command_interfaces: [position]
+    state_interfaces: [position, velocity]
+    joints:
+      - <robot_namespace>shoulder_pan_joint
+      - <robot_namespace>shoulder_lift_joint
+      - <robot_namespace>elbow_flex_joint
+      - <robot_namespace>wrist_flex_joint
+      - <robot_namespace>wrist_roll_joint
+
+forward_position_controller:
+  ros__parameters:
+    joints:
+      - <robot_namespace>shoulder_pan_joint
+      - <robot_namespace>shoulder_lift_joint
+      - <robot_namespace>elbow_flex_joint
+      - <robot_namespace>wrist_flex_joint
+      - <robot_namespace>wrist_roll_joint
+      - <robot_namespace>gripper_joint  # gripper: single-topic commands for rosetta/inference

--- a/pai_bringup/launch/so_arm_mujoco_bringup.launch.py
+++ b/pai_bringup/launch/so_arm_mujoco_bringup.launch.py
@@ -28,9 +28,10 @@ def generate_launch_description():
     )
     robot_description = {"robot_description": ParameterValue(value=robot_description_content, value_type=str)}
 
-    # Apply empty namespaces to controller parameters file.
+    # MuJoCo config: forward_position_controller with 6 joints (incl. gripper_joint)
+    # for arm_demo_positions.sh, rosetta, and inference (so_arm101 has 5 joints only).
     ros2_controllers_file = PathJoinSubstitution(
-        [FindPackageShare("so_arm101_description"), "control", "ros2_controllers.yaml"]
+        [FindPackageShare("pai_bringup"), "config", "ros2_controllers_mujoco.yaml"]
     )
     ros2_controllers_file = ReplaceString(
         source_file=ros2_controllers_file,
@@ -76,24 +77,25 @@ def generate_launch_description():
         output="both",
     )
 
-    spawn_jtc = Node(
+    spawn_forward_position_controller = Node(
         package="controller_manager",
         executable="spawner",
-        name="spawn_joint_trajectory_controller",
+        name="spawn_forward_position_controller",
         arguments=[
-            "joint_trajectory_controller",
+            "forward_position_controller",
         ],
         output="both",
     )
 
-    spawn_gripper_controller = Node(
-        package="controller_manager",
-        executable="spawner",
-        name="spawn_gripper_controller",
-        arguments=[
-            "gripper_controller",
-        ],
+    camera_relay = Node(
+        package="pai_bringup",
+        executable="camera_relay_node",
+        name="camera_relay_node",
         output="both",
+        parameters=[
+            {"input_topic": "/camera/color/image_raw"},
+            {"output_topic": "/camera"},
+        ],
     )
 
     rviz_config_file = PathJoinSubstitution(
@@ -112,8 +114,8 @@ def generate_launch_description():
             robot_state_publisher_node,
             control_node,
             spawn_joint_state_broadcaster,
-            spawn_jtc,
-            spawn_gripper_controller,
+            spawn_forward_position_controller,
+            camera_relay,
             rviz_node,
         ]
     )

--- a/pai_bringup/scripts/camera_relay_node
+++ b/pai_bringup/scripts/camera_relay_node
@@ -1,0 +1,49 @@
+# Copyright (C) 2026 Julia Jia
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+"""Relay node: republishes /camera/color/image_raw to /camera for MuJoCo sim."""
+
+import rclpy
+from rclpy.node import Node
+from sensor_msgs.msg import Image
+
+
+class CameraRelayNode(Node):
+    def __init__(self):
+        super().__init__("camera_relay_node")
+        self.declare_parameter("input_topic", "/camera/color/image_raw")
+        self.declare_parameter("output_topic", "/camera")
+        input_topic = self.get_parameter("input_topic").value
+        output_topic = self.get_parameter("output_topic").value
+        self.sub = self.create_subscription(Image, input_topic, self.callback, 10)
+        self.pub = self.create_publisher(Image, output_topic, 10)
+        self.get_logger().info(f"Relaying {input_topic} -> {output_topic}")
+
+    def callback(self, msg):
+        self.pub.publish(msg)
+
+
+def main(args=None):
+    rclpy.init(args=args)
+    node = CameraRelayNode()
+    try:
+        rclpy.spin(node)
+    finally:
+        node.destroy_node()
+        rclpy.shutdown()
+
+
+if __name__ == "__main__":
+    main()

--- a/pai_data_collection/config/rosetta/so_arm101.yaml
+++ b/pai_data_collection/config/rosetta/so_arm101.yaml
@@ -1,4 +1,4 @@
-robot_type: so_arm100
+robot_type: so_arm101
 
 # Recording parameters
 fps: 50  # Matches controller update rate
@@ -23,7 +23,7 @@ observations:
         position.shoulder_pan_joint,
         position.shoulder_lift_joint,
         position.elbow_flex_joint,
-        position.wrist_pitch_joint,
+        position.wrist_flex_joint,
         position.wrist_roll_joint,
         position.gripper_joint,
       ]

--- a/pixi.toml
+++ b/pixi.toml
@@ -23,9 +23,17 @@ start_zenoh = { cmd = [
 ]}
 so-arm-gz = { cmd = ["ros2", "launch", "pai_bringup", "so_arm_gz_bringup.launch.py"] }
 so-arm-mujoco = { cmd = ["ros2", "launch", "pai_bringup", "so_arm_mujoco_bringup.launch.py"] }
+rosetta-record-mujoco = { cmd = [
+  "ros2",
+  "launch",
+  "rosetta",
+  "episode_recorder_launch.py",
+  "contract_path:=$(ros2 pkg prefix pai_data_collection)/share/pai_data_collection/config/rosetta/so_arm101.yaml",
+  "bag_base_dir:=datasets/so_arm101_mujoco/bags",
+] }
 # Run LeRobot inference node
-# Note: policy_path defaults to 'outputs/train/act_move_to_cube/checkpoints/040000/pretrained_model'
-# Override it via: pixi run lerobot-inference --ros-args -p policy_path:=/path/to/your/model
+# Download model first: python pai_bringup/test/download_lerobot_model
+# Override: pixi run lerobot-inference --ros-args -p policy_path:=/path/to/model
 lerobot-inference = { cmd = [
   "python3",
   "pai_bringup/scripts/lerobot_inference_node",


### PR DESCRIPTION
An add-on to https://github.com/ros-physical-ai/demos/pull/3 for rosetta collection ... 

- Updates so_arm_mujoco_bringup.launch.py): uses forward_position_controller (6 joints including gripper) instead of joint_trajectory_controller, adds camera relay (/camera/color/image_raw → /camera).
- Renamed from so_arm100.yaml to so_arm101.yaml. Updates wrist_pitch_joint → wrist_flex_joint in observation.state.
- pixi.toml: Added more task for rosetta-record-mujoco; so-arm-mujoco now runs bringup with camera relay.
- README (pai_data_collection): Documented MuJoCo data collection flow .

