### PR TITLE
Fix mujoco's gripper pos and range.

### DIFF
--- a/pai.repos
+++ b/pai.repos
@@ -2,7 +2,7 @@ repositories:
   SO-ARM100/ros2_so_arm100:
     type: git
     url: https://github.com/JafarAbdi/ros2_so_arm.git
-    version: 5f1af89bc8dcea91f7282c9c1aa583da739c6818
+    version: 12fbcb8cf30da7c3d679db384c43765ea311eb18
   SO-ARM100/feetech_ros2_driver:
     type: git
     url: https://github.com/legalaspro/feetech_ros2_driver.git

--- a/pai_bringup/mjcf/so_arm101.xml.xacro
+++ b/pai_bringup/mjcf/so_arm101.xml.xacro
@@ -375,13 +375,13 @@
                 <body
                   name="jaw_link"
                   pos="0.0202 0.0188 -0.0234"
-                  quat="0.707107 0.707107 -1.85362e-08 1.85362e-08"
+                  quat="0.7042449 0.7042449 0.0635537 -0.0635537"
                 >
                   <joint
                     axis="0 0 1"
                     name="gripper_joint"
                     type="hinge"
-                    range="-0.17453297762778586 1.7453291995659765"
+                    range="0.0 1.70"
                     class="sts3215"
                   />
                   <inertial
@@ -461,7 +461,7 @@
       name="gripper_joint"
       joint="gripper_joint"
       forcerange="-3.35 3.35"
-      ctrlrange="-0.17453 1.74533"
+      ctrlrange="0.0 1.70"
     />
   </actuator>
 


### PR DESCRIPTION
Goes on top of #39 (It just goes on top as the mjcf is also being modified for a different reason (cameras))

### Summary

There was a discrepancy between arm101 gazebo simulation (which is based on real urdf) and the mujoco simulation.
This was related to the position of the gripper link and its range causing that the same position sent to the gazebo and mujoco simulation presented different position being the mistake in the mujoco simulation.

### This PR

Fixes the model to behave the same.