### PR TITLE
Add videos to the readme on real demos

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,59 @@ With Pixi: `pixi run so-arm-leader`
 
 Record demonstrations, train a policy, and deploy it on the robot — in simulation or on real hardware, using any input method (leader arm teleoperation, scripted commands, or custom controllers).
 
+#### Recording episodes
+
+<table>
+<tr>
+<td align="center"><b>Simulation</b></td>
+<td align="center"><b>Real Hardware</b></td>
+</tr>
+<tr>
+<td>
+
+https://github.com/user-attachments/assets/9bd16f15-358f-44e2-80f8-df01aaca47c0
+
+</td>
+<td>
+
+https://github.com/user-attachments/assets/bcc907b0-0914-43be-89ee-5bd161139264
+
+</td>
+</tr>
+<tr>
+<td align="center"><em>Recording episodes in Gazebo via leader arm teleoperation</em></td>
+<td align="center"><em>Recording episodes on real SO-ARM101</em></td>
+</tr>
+</table>
+
+#### Trained policy inference
+
+<table>
+<tr>
+<td align="center"><b>Simulation</b></td>
+<td align="center"><b>Real Hardware</b></td>
+</tr>
+<tr>
+<td>
+
+https://github.com/user-attachments/assets/9183df05-4db4-46b4-90ef-56cfd50b56c2
+
+</td>
+<td>
+
+https://github.com/user-attachments/assets/51beafa7-4d85-4a53-b0db-ec593f663850
+
+</td>
+</tr>
+<tr>
+<td align="center"><em>Trained policy running in Gazebo</em></td>
+<td align="center"><em>Trained policy running on real SO-ARM101</em></td>
+</tr>
+</table>
+
+> [!NOTE]
+> These videos show an **ACT** policy trained on the recorded episodes. The goal here is to demonstrate the full **Record → Train → Deploy** pipeline — not to showcase optimal policy performance, which depends on the number of episodes, model selection, and hyperparameter tuning.
+
 For the full pipeline guide see [End-to-End Learning Pipeline with Rosetta](./demos/so_arm_101/rosetta_end_to_end_demo.md).
 
 ## Linting & Pre-commit

--- a/demos/so_arm_101/rosetta_end_to_end_demo.md
+++ b/demos/so_arm_101/rosetta_end_to_end_demo.md
@@ -11,6 +11,9 @@ This guide explains the full Record → Train → Deploy pipeline using [Rosetta
 
 The pipeline is **not tied to a specific task**. The same workflow applies whether you are teaching the robot to pick and place objects, sort items, wave, or perform any other manipulation behavior — only the recorded demonstrations define what the policy learns.
 
+> [!TIP]
+> See the [main README](../../README.md#demos) for videos of the full pipeline in action — recording demonstrations via leader arm teleoperation and deploying trained policies, in both simulation and on real hardware.
+
 ## Prerequisites
 
 Follow the main [README](../../README.md) to set up the workspace:


### PR DESCRIPTION
## Summary

related to #43 

- Add videos to the readme showing episodes recording and inference running for both sim and real cases

## Test it

Check demos section on this branch

<img width="981" height="1129" alt="image" src="https://github.com/user-attachments/assets/2cdf5276-f707-416c-bd6c-6eecd947fc0b" />
