### PR TITLE
Note about source workspace

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,13 @@ pixi install
 pixi run build
 ```
 
+Source the workspace before running demos:
+
+```bash
+source install/setup.bash
+```
+
+
 To install ML dependencies (PyTorch, LeRobot — automatically detects your GPU):
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ Source the workspace before running demos:
 source install/setup.bash
 ```
 
-
 To install ML dependencies (PyTorch, LeRobot — automatically detects your GPU):
 
 ```bash


### PR DESCRIPTION
There is a note in the "manual install without Pixi" that says: "When using this approach, source the workspace before running demos"

The reality is that, at least for me, I also need to source the workspace before running the demos even when using Pixi.

If that's true, we should add this step.