### PR TITLE
Rerun live visualization.

### DIFF
--- a/pai_bringup/launch/include/so_arm_common.launch.py
+++ b/pai_bringup/launch/include/so_arm_common.launch.py
@@ -28,9 +28,13 @@ Nodes launched:
   - rviz2 (optional, delayed until joint_state_broadcaster is ready)
 """
 
+import os
+
+from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
-from launch.actions import DeclareLaunchArgument, OpaqueFunction, RegisterEventHandler
+from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription, OpaqueFunction, RegisterEventHandler
 from launch.event_handlers import OnProcessExit
+from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import (
     Command,
     FindExecutable,
@@ -51,6 +55,7 @@ def launch_setup(context, *args, **kwargs):
     activate_joint_controller = LaunchConfiguration("activate_joint_controller").perform(context).lower() == "true"
     launch_rviz = LaunchConfiguration("launch_rviz").perform(context).lower() == "true"
     rviz_config_file = LaunchConfiguration("rviz_config_file").perform(context)
+    launch_rerun = LaunchConfiguration("launch_rerun").perform(context).lower() == "true"
 
     # Build robot description via xacro
     xacro_cmd = [
@@ -133,6 +138,24 @@ def launch_setup(context, *args, **kwargs):
         )
         nodes.append(delay_rviz_after_joint_state_broadcaster)
 
+    if launch_rerun:
+        rerun_visualizer = IncludeLaunchDescription(
+            PythonLaunchDescriptionSource(
+                os.path.join(
+                    get_package_share_directory("pai_rerun_visualizer"),
+                    "launch",
+                    "visualizer.launch.py",
+                )
+            ),
+        )
+        delay_rerun_after_joint_state_broadcaster = RegisterEventHandler(
+            event_handler=OnProcessExit(
+                target_action=joint_state_broadcaster_spawner,
+                on_exit=[rerun_visualizer],
+            ),
+        )
+        nodes.append(delay_rerun_after_joint_state_broadcaster)
+
     return nodes
 
 
@@ -181,6 +204,11 @@ def generate_launch_description():
         DeclareLaunchArgument(
             "rviz_config_file",
             description="RViz config file to use.",
+        ),
+        DeclareLaunchArgument(
+            "launch_rerun",
+            default_value="true",
+            description="Launch the pai_rerun_visualizer node.",
         ),
     ]
 

--- a/pai_bringup/launch/so_arm_gz_bringup.launch.py
+++ b/pai_bringup/launch/so_arm_gz_bringup.launch.py
@@ -40,6 +40,7 @@ def launch_setup(context, *args, **kwargs):
     initial_joint_controller = LaunchConfiguration("initial_joint_controller").perform(context)
     description_file = LaunchConfiguration("description_file").perform(context)
     launch_rviz = LaunchConfiguration("launch_rviz").perform(context)
+    launch_rerun = LaunchConfiguration("launch_rerun").perform(context)
     rviz_config_file = LaunchConfiguration("rviz_config_file").perform(context)
     gazebo_gui = LaunchConfiguration("gazebo_gui").perform(context)
     world_file = LaunchConfiguration("world_file")
@@ -100,6 +101,7 @@ def launch_setup(context, *args, **kwargs):
             "activate_joint_controller": activate_joint_controller,
             "launch_rviz": launch_rviz,
             "rviz_config_file": rviz_config_file,
+            "launch_rerun": launch_rerun,
         }.items(),
     )
 
@@ -197,6 +199,9 @@ def generate_launch_description():
             description="URDF/XACRO description file (absolute path) with the robot.",
         ),
         DeclareLaunchArgument("launch_rviz", default_value="true", description="Launch RViz?"),
+        DeclareLaunchArgument(
+            "launch_rerun", default_value="true", description="Launch the pai_rerun_visualizer node?"
+        ),
         DeclareLaunchArgument(
             "rviz_config_file",
             default_value=PathJoinSubstitution([FindPackageShare("pai_bringup"), "config", "rviz", "so_arm_101.rviz"]),

--- a/pai_bringup/launch/so_arm_mujoco_bringup.launch.py
+++ b/pai_bringup/launch/so_arm_mujoco_bringup.launch.py
@@ -101,6 +101,8 @@ def _generate_mjcf_at_launch(pkg_share, world_sdf_path, arm_base_xyz, arm_base_r
 
 def launch_setup(context, *args, **kwargs):
     """Set up nodes for the SO ARM MuJoCo bringup."""
+    launch_rviz = LaunchConfiguration("launch_rviz").perform(context)
+    launch_rerun = LaunchConfiguration("launch_rerun").perform(context)
     pkg_share = PathJoinSubstitution([FindPackageShare("pai_bringup")]).perform(context)
     world_sdf_path = LaunchConfiguration("world_file").perform(context)
     arm_base_xyz = (
@@ -160,6 +162,7 @@ def launch_setup(context, *args, **kwargs):
             ),
             "description_xacro_args": description_xacro_args,
             "use_sim_time": "true",
+            "launch_rviz": launch_rviz,
             "rviz_config_file": PathJoinSubstitution(
                 [
                     FindPackageShare("pai_bringup"),
@@ -168,6 +171,7 @@ def launch_setup(context, *args, **kwargs):
                     "so_arm_101.rviz",
                 ]
             ),
+            "launch_rerun": launch_rerun,
         }.items(),
     )
 
@@ -188,5 +192,9 @@ def generate_launch_description():
         DeclareLaunchArgument("roll", default_value="0.0", description="Robot arm base roll orientation (radians)"),
         DeclareLaunchArgument("pitch", default_value="0.0", description="Robot arm base pitch orientation (radians)"),
         DeclareLaunchArgument("yaw", default_value="3.14159", description="Robot arm base yaw orientation (radians)"),
+        DeclareLaunchArgument("launch_rviz", default_value="true", description="Launch RViz?"),
+        DeclareLaunchArgument(
+            "launch_rerun", default_value="true", description="Launch the pai_rerun_visualizer node?"
+        ),
     ]
     return LaunchDescription([*declared_arguments, OpaqueFunction(function=launch_setup)])

--- a/pai_bringup/launch/so_arm_real_bringup.launch.py
+++ b/pai_bringup/launch/so_arm_real_bringup.launch.py
@@ -39,6 +39,7 @@ def launch_setup(context, *args, **kwargs):
     ros2_control_file = LaunchConfiguration("ros2_control_file").perform(context)
     initial_joint_controller = LaunchConfiguration("initial_joint_controller").perform(context)
     launch_rviz = LaunchConfiguration("launch_rviz").perform(context)
+    launch_rerun = LaunchConfiguration("launch_rerun").perform(context)
     rviz_config_file = LaunchConfiguration("rviz_config_file").perform(context)
     use_cameras = LaunchConfiguration("use_cameras")
     cameras_config_file = LaunchConfiguration("cameras_config_file").perform(context)
@@ -94,6 +95,7 @@ def launch_setup(context, *args, **kwargs):
             "initial_joint_controller": initial_joint_controller,
             "launch_rviz": launch_rviz,
             "rviz_config_file": rviz_config_file,
+            "launch_rerun": launch_rerun,
         }.items(),
     )
 
@@ -178,6 +180,11 @@ def generate_launch_description():
             "launch_rviz",
             default_value="true",
             description="Launch RViz?",
+        ),
+        DeclareLaunchArgument(
+            "launch_rerun",
+            default_value="true",
+            description="Launch the pai_rerun_visualizer node?",
         ),
         DeclareLaunchArgument(
             "rviz_config_file",

--- a/pai_bringup/package.xml
+++ b/pai_bringup/package.xml
@@ -21,6 +21,7 @@
   <exec_depend>mujoco_ros2_control</exec_depend>
   <exec_depend>pai_assets</exec_depend>
   <exec_depend>pai_description</exec_depend>
+  <exec_depend>pai_rerun_visualizer</exec_depend>
   <exec_depend>nav2_common</exec_depend>
   <exec_depend>parallel_gripper_controller</exec_depend>
   <exec_depend>rclpy</exec_depend>

--- a/pai_rerun_visualizer/CMakeLists.txt
+++ b/pai_rerun_visualizer/CMakeLists.txt
@@ -1,0 +1,28 @@
+cmake_minimum_required(VERSION 3.8)
+project(pai_rerun_visualizer)
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+find_package(ament_cmake REQUIRED)
+find_package(ament_cmake_python REQUIRED)
+find_package(rclpy REQUIRED)
+
+# Install the Python package (importable modules).
+ament_python_install_package(${PROJECT_NAME})
+
+# Install the node entry point as an executable runnable via `ros2 run`.
+install(PROGRAMS
+  scripts/visualizer_node
+  DESTINATION lib/${PROJECT_NAME}
+)
+
+# Install launch files and configuration.
+install(DIRECTORY
+  launch
+  config
+  DESTINATION share/${PROJECT_NAME}
+)
+
+ament_package()

--- a/pai_rerun_visualizer/CMakeLists.txt
+++ b/pai_rerun_visualizer/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.22)
 project(pai_rerun_visualizer)
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")

--- a/pai_rerun_visualizer/config/visualizer.yaml
+++ b/pai_rerun_visualizer/config/visualizer.yaml
@@ -19,7 +19,7 @@
     ee_frame: gripper_frame_link
 
     # Optical convention for the rr.Pinhole frustum (RDF = standard camera optical).
-    camera_xyz: RDF
+    camera_optical_convention: RDF
 
     # Joint order matching the forward_position_controller "commands" payload.
     cmd_joints:

--- a/pai_rerun_visualizer/config/visualizer.yaml
+++ b/pai_rerun_visualizer/config/visualizer.yaml
@@ -1,0 +1,41 @@
+# Parameters for the pai_rerun_visualizer node.
+# Topic names default to the flat names used across the gazebo, mujoco and real
+# SO-ARM101 bringups.
+/**:
+  ros__parameters:
+    # Spatial layer topics
+    robot_description_topic: /robot_description
+    joint_states_topic: /joint_states
+    wrist_image_topic: /wrist_camera/image_raw
+    wrist_camera_info_topic: /wrist_camera/camera_info
+    static_image_topic: /static_camera/image_raw
+    static_camera_info_topic: /static_camera/camera_info
+
+    # Action / ML layer topics
+    forward_commands_topic: /forward_position_controller/commands
+    action_chunk_topic: /inference/action_chunk
+
+    # Forward-kinematics end-effector frame used for the predicted path.
+    ee_frame: gripper_frame_link
+
+    # Optical convention for the rr.Pinhole frustum (RDF = standard camera optical).
+    camera_xyz: RDF
+
+    # Joint order matching the forward_position_controller "commands" payload.
+    cmd_joints:
+      - shoulder_pan_joint
+      - shoulder_lift_joint
+      - elbow_flex_joint
+      - wrist_flex_joint
+      - wrist_roll_joint
+      - gripper_joint
+
+    # Predicted trajectory colour (RGB 0-255).
+    trajectory_color: [0, 255, 0]
+
+    # Rerun viewer: "web" (gRPC + browser) or "native" (desktop app).
+    viewer: web
+    rerun_memory_limit: 512MB
+
+    # Maximum update rate for the visualizer (Hz).
+    viz_max_hz: 30.

--- a/pai_rerun_visualizer/launch/visualizer.launch.py
+++ b/pai_rerun_visualizer/launch/visualizer.launch.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+
+# Copyright 2026 Franco Cipollone
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Launch the pai_rerun_visualizer node with parameters from a YAML file."""
+
+import os
+
+from ament_index_python.packages import get_package_share_directory
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument
+from launch.substitutions import LaunchConfiguration
+from launch_ros.actions import Node
+
+
+def generate_launch_description():
+    """Generate a launch description for the pai_rerun_visualizer node."""
+    pkg_share = get_package_share_directory("pai_rerun_visualizer")
+    default_params = os.path.join(pkg_share, "config", "visualizer.yaml")
+
+    params_file = LaunchConfiguration("params_file")
+
+    return LaunchDescription(
+        [
+            DeclareLaunchArgument(
+                "params_file",
+                default_value=default_params,
+                description="YAML parameter file for the visualizer node.",
+            ),
+            Node(
+                package="pai_rerun_visualizer",
+                executable="visualizer_node",
+                name="pai_rerun_visualizer",
+                output="screen",
+                parameters=[params_file],
+            ),
+        ]
+    )

--- a/pai_rerun_visualizer/package.xml
+++ b/pai_rerun_visualizer/package.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>pai_rerun_visualizer</name>
+  <version>0.1.0</version>
+  <description>
+    Rerun visualization node for the SO-ARM101 physical-AI demos. Renders the
+    robot mesh (pinocchio forward kinematics), camera feeds with pinhole
+    projection, joint plots and predicted action-chunk trajectories on the
+    Rerun temporal timeline.
+  </description>
+  <maintainer email="franco.cipollone@ekumenlabs.com">Franco Cipollone</maintainer>
+  <license>Apache-2.0</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>ament_cmake_python</buildtool_depend>
+
+  <exec_depend>rclpy</exec_depend>
+  <exec_depend>cv_bridge</exec_depend>
+  <exec_depend>sensor_msgs</exec_depend>
+  <exec_depend>std_msgs</exec_depend>
+  <exec_depend>geometry_msgs</exec_depend>
+  <exec_depend>trajectory_msgs</exec_depend>
+  <exec_depend>tf2_msgs</exec_depend>
+  <exec_depend>ament_index_python</exec_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/pai_rerun_visualizer/pai_rerun_visualizer/__init__.py
+++ b/pai_rerun_visualizer/pai_rerun_visualizer/__init__.py
@@ -1,0 +1,1 @@
+"""Rerun visualization for the SO-ARM101 physical-AI demos."""

--- a/pai_rerun_visualizer/pai_rerun_visualizer/robot_model.py
+++ b/pai_rerun_visualizer/pai_rerun_visualizer/robot_model.py
@@ -1,0 +1,202 @@
+# Copyright 2026 Franco Cipollone
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Pinocchio-backed kinematic model built from a live URDF string.
+
+This module isolates everything that depends on ``pinocchio`` so the ROS node
+stays focused on message plumbing and Rerun logging. It provides:
+
+* forward kinematics for arbitrary URDF frames given a joint name -> value map,
+* parsing of the URDF ``<visual>`` meshes (path, origin, scale) so the meshes
+  can be logged to Rerun as ``rr.Asset3D`` and posed each frame.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import xml.etree.ElementTree as ET
+from dataclasses import dataclass
+from typing import Optional
+
+import numpy as np
+import pinocchio as pin
+from ament_index_python.packages import PackageNotFoundError, get_package_share_directory
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class VisualMesh:
+    """A single URDF visual mesh attached to a link."""
+
+    link: str  # URDF link (frame) the visual is rigidly attached to
+    mesh_path: str  # absolute filesystem path to the mesh file
+    origin: np.ndarray  # 4x4 link_T_visual transform
+    scale: np.ndarray  # (3,) per-axis mesh scale
+    color: Optional[np.ndarray] = None  # RGBA in [0, 1] from URDF <material>, or None if unset
+
+
+def _xyz_rpy_to_matrix(xyz: list[float], rpy: list[float]) -> np.ndarray:
+    """Build a 4x4 homogeneous transform from URDF xyz + rpy (radians)."""
+    rot = pin.rpy.rpyToMatrix(rpy[0], rpy[1], rpy[2])
+    mat = np.eye(4)
+    mat[:3, :3] = rot
+    mat[:3, 3] = np.asarray(xyz, dtype=float)
+    return mat
+
+
+def _resolve_mesh_path(filename: str) -> Optional[str]:
+    """Resolve a URDF mesh ``filename`` (package:// or file://) to a real path."""
+    if filename.startswith("package://"):
+        rest = filename[len("package://") :]
+        pkg, _, rel = rest.partition("/")
+        try:
+            share = get_package_share_directory(pkg)
+        except PackageNotFoundError:
+            return None
+        return os.path.join(share, rel)
+    if filename.startswith("file://"):
+        return filename[len("file://") :]
+    return filename if os.path.isabs(filename) else None
+
+
+class RobotModel:
+    """Forward kinematics + visual geometry parsed from a URDF XML string."""
+
+    def __init__(self, urdf_xml: str) -> None:
+        """Build the pinocchio model from a URDF XML string and parse visual meshes."""
+        self._model = pin.buildModelFromXML(urdf_xml)
+        self._data = self._model.createData()
+        # Map every actuated joint name to its configuration index in ``q``.
+        self._name_to_qidx: dict[str, int] = {}
+        for jid in range(1, self._model.njoints):  # joint 0 is the universe
+            joint = self._model.joints[jid]
+            if joint.nq == 1:
+                self._name_to_qidx[self._model.names[jid]] = joint.idx_q
+        self._q = pin.neutral(self._model)
+        self.visuals: list[VisualMesh] = self._parse_visuals(urdf_xml)
+
+    # -- configuration -------------------------------------------------
+    def set_joint_positions(self, name_to_value: dict[str, float]) -> None:
+        """Update the internal configuration from a joint name -> radians map."""
+        for name, value in name_to_value.items():
+            qidx = self._name_to_qidx.get(name)
+            if qidx is not None:
+                self._q[qidx] = value
+        pin.forwardKinematics(self._model, self._data, self._q)
+        pin.updateFramePlacements(self._model, self._data)
+
+    def frame_pose(self, frame: str) -> Optional[np.ndarray]:
+        """Return the 4x4 world_T_frame transform, or ``None`` if unknown."""
+        if not self._model.existFrame(frame):
+            return None
+        fid = self._model.getFrameId(frame)
+        placement = self._data.oMf[fid]
+        mat = np.eye(4)
+        mat[:3, :3] = placement.rotation
+        mat[:3, 3] = placement.translation
+        return mat
+
+    def has_frame(self, frame: str) -> bool:
+        """Return ``True`` if *frame* exists in the pinocchio model."""
+        return self._model.existFrame(frame)
+
+    # -- URDF visual parsing -------------------------------------------
+    @staticmethod
+    def _parse_visuals(urdf_xml: str) -> list[VisualMesh]:
+        """Extract all mesh-backed visual elements from the URDF XML.
+
+        Walks every ``<link>/<visual>/<geometry>/<mesh>`` element, resolves the
+        mesh file path, reads the ``<origin>`` transform and per-axis scale, and
+        returns a list of :class:`VisualMesh` instances ready for Rerun logging.
+        Primitive geometries (box / cylinder / sphere) are silently skipped.
+        """
+        visuals: list[VisualMesh] = []
+        try:
+            root = ET.fromstring(urdf_xml)
+        except ET.ParseError:
+            return visuals
+
+        # Pre-parse robot-level named materials: <material name="..."><color rgba="..."/>.
+        named_materials: dict[str, np.ndarray] = {}
+        for mat in root.findall("material"):
+            mat_name = mat.get("name")
+            color_el = mat.find("color")
+            if mat_name and color_el is not None:
+                rgba_str = color_el.get("rgba")
+                if rgba_str:
+                    named_materials[mat_name] = np.array([float(v) for v in rgba_str.split()], dtype=float)
+
+        for link in root.findall("link"):
+            link_name = link.get("name")
+            if not link_name:
+                continue
+            for visual in link.findall("visual"):
+                geometry = visual.find("geometry")
+                if geometry is None:
+                    continue
+                mesh = geometry.find("mesh")
+                if mesh is None:
+                    logging.warning(
+                        "URDF visual geometry for link '%s' is not a mesh, skipping (only <mesh> is supported)",
+                        link_name,
+                    )
+                    continue
+                filename = mesh.get("filename")
+                if not filename:
+                    continue
+                mesh_path = _resolve_mesh_path(filename)
+                if not mesh_path or not os.path.exists(mesh_path):
+                    continue
+
+                origin_el = visual.find("origin")
+                xyz = [0.0, 0.0, 0.0]
+                rpy = [0.0, 0.0, 0.0]
+                if origin_el is not None:
+                    if origin_el.get("xyz"):
+                        xyz = [float(v) for v in origin_el.get("xyz").split()]
+                    if origin_el.get("rpy"):
+                        rpy = [float(v) for v in origin_el.get("rpy").split()]
+                origin = _xyz_rpy_to_matrix(xyz, rpy)
+
+                scale = np.ones(3)
+                if mesh.get("scale"):
+                    scale = np.asarray([float(v) for v in mesh.get("scale").split()])
+
+                # Resolve material color: prefer inline <color rgba="...">,
+                # fall back to a robot-level named material.
+                color: Optional[np.ndarray] = None
+                material_el = visual.find("material")
+                if material_el is not None:
+                    color_el = material_el.find("color")
+                    if color_el is not None:
+                        rgba_str = color_el.get("rgba")
+                        if rgba_str:
+                            color = np.array([float(v) for v in rgba_str.split()], dtype=float)
+                    if color is None:
+                        ref_name = material_el.get("name")
+                        if ref_name:
+                            color = named_materials.get(ref_name)
+
+                visuals.append(
+                    VisualMesh(
+                        link=link_name,
+                        mesh_path=mesh_path,
+                        origin=origin,
+                        scale=scale,
+                        color=color,
+                    )
+                )
+        return visuals

--- a/pai_rerun_visualizer/pai_rerun_visualizer/visualizer_node.py
+++ b/pai_rerun_visualizer/pai_rerun_visualizer/visualizer_node.py
@@ -114,7 +114,7 @@ class VisualizerNode(Node):
         topics: Topics,
         cmd_joint_order: list[str],
         ee_frame: str,
-        camera_xyz: str,
+        camera_optical_convention: str,
         trajectory_color: tuple[int, int, int],
         viz_max_hz: float = 30.0,
     ) -> None:
@@ -124,7 +124,7 @@ class VisualizerNode(Node):
             topics: Grouped ROS topic names for all subscriptions.
             cmd_joint_order: Ordered joint names matching ``forward_commands`` array indices.
             ee_frame: URDF frame used as the end-effector for trajectory FK.
-            camera_xyz: Rerun ``ViewCoordinates`` key (e.g. ``"RDF"``) for camera orientation.
+            camera_optical_convention: Rerun ``ViewCoordinates`` key (e.g. ``"RDF"``) for camera orientation.
             trajectory_color: RGB tuple for the predicted action-chunk path overlay.
             viz_max_hz: Maximum rate (Hz) at which 3D transforms and camera images are
                 sent to Rerun.  Scalar time-series are exempt and always logged at the
@@ -136,7 +136,7 @@ class VisualizerNode(Node):
         self._topics = topics
         self._cmd_joint_order = list(cmd_joint_order)
         self._ee_frame = ee_frame
-        self._camera_xyz = _VIEW_COORDS.get(camera_xyz.upper(), rr.ViewCoordinates.RDF)
+        self._camera_optical_convention = _VIEW_COORDS.get(camera_optical_convention.upper(), rr.ViewCoordinates.RDF)
         self._traj_color = trajectory_color
         self._viz_min_interval_s: float = 1.0 / max(viz_max_hz, 0.1)
 
@@ -340,7 +340,9 @@ class VisualizerNode(Node):
         self._cam_info[cam_name] = (k, msg.width, msg.height, msg.header.frame_id)
         rr.log(
             f"cameras/{cam_name}",
-            rr.Pinhole(image_from_camera=k, resolution=[msg.width, msg.height], camera_xyz=self._camera_xyz),
+            rr.Pinhole(
+                image_from_camera=k, resolution=[msg.width, msg.height], camera_xyz=self._camera_optical_convention
+            ),
             static=True,
         )
 
@@ -424,7 +426,7 @@ def main() -> None:
     static_image = str(_declare(bootstrap, "static_image_topic", "/static_camera/image_raw"))
     static_info = str(_declare(bootstrap, "static_camera_info_topic", "/static_camera/camera_info"))
     ee_frame = str(_declare(bootstrap, "ee_frame", "gripper_frame_link"))
-    camera_xyz = str(_declare(bootstrap, "camera_xyz", "RDF"))
+    camera_optical_convention = str(_declare(bootstrap, "camera_optical_convention", "RDF"))
     cmd_joints = list(
         _declare(
             bootstrap,
@@ -490,7 +492,7 @@ def main() -> None:
         topics,
         cmd_joint_order=cmd_joints,
         ee_frame=ee_frame,
-        camera_xyz=camera_xyz,
+        camera_optical_convention=camera_optical_convention,
         trajectory_color=(int(traj_color[0]), int(traj_color[1]), int(traj_color[2])),
         viz_max_hz=viz_max_hz,
     )

--- a/pai_rerun_visualizer/pai_rerun_visualizer/visualizer_node.py
+++ b/pai_rerun_visualizer/pai_rerun_visualizer/visualizer_node.py
@@ -1,0 +1,512 @@
+# Copyright 2026 Franco Cipollone
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""SO-ARM101 ROS 2 -> Rerun visualizer.
+
+Spatial layer (standard ROS 2):
+  * robot mesh posed via pinocchio forward kinematics from ``/joint_states``,
+  * camera images logged as ``rr.Image`` with ``rr.Pinhole`` projection,
+  * joint-position time series.
+
+ML layer (tensors):
+  * predicted action-chunk trajectory (``trajectory_msgs/JointTrajectory``)
+    turned into a 3D end-effector path via forward kinematics and drawn as a
+    fading ``rr.LineStrips3D`` + ``rr.Points3D`` extending from the gripper.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from dataclasses import dataclass, field
+from functools import partial
+from typing import Optional
+
+import numpy as np
+import rclpy
+import rerun as rr
+import rerun.blueprint as rrb
+from cv_bridge import CvBridge
+from rclpy.callback_groups import ReentrantCallbackGroup
+from rclpy.executors import MultiThreadedExecutor
+from rclpy.node import Node
+from rclpy.qos import (
+    DurabilityPolicy,
+    QoSProfile,
+    ReliabilityPolicy,
+    qos_profile_sensor_data,
+)
+from rclpy.time import Time
+from sensor_msgs.msg import CameraInfo, Image, JointState
+from std_msgs.msg import Float64MultiArray, String
+from trajectory_msgs.msg import JointTrajectory
+
+from pai_rerun_visualizer.robot_model import RobotModel
+
+_VIEW_COORDS = {
+    "RDF": rr.ViewCoordinates.RDF,
+    "FLU": rr.ViewCoordinates.FLU,
+    "RUB": rr.ViewCoordinates.RUB,
+    "FRD": rr.ViewCoordinates.FRD,
+}
+
+_MONO_ENCODINGS = {"mono8", "mono16", "32fc1", "16uc1"}
+_cv_bridge = CvBridge()
+
+
+def stamp_to_datetime64(stamp) -> np.datetime64:
+    """Convert a ROS 2 ``builtin_interfaces/Time`` stamp to ``np.datetime64`` nanoseconds."""
+    return np.datetime64(Time.from_msg(stamp).nanoseconds, "ns")
+
+
+def image_to_numpy(msg: Image) -> tuple[Optional[np.ndarray], Optional[str]]:
+    """Convert a ``sensor_msgs/Image`` to a numpy array + Rerun color model.
+
+    Uses ``cv_bridge`` for robust handling of all ROS image encodings (bayer,
+    yuv, 16-bit, float, etc.).  Mono/depth images are kept as single-channel
+    ``uint8``; all colour images are converted to ``rgb8``.
+    """
+    is_mono = (msg.encoding or "").lower() in _MONO_ENCODINGS
+    desired = "mono8" if is_mono else "rgb8"
+    try:
+        img = _cv_bridge.imgmsg_to_cv2(msg, desired_encoding=desired)
+    except Exception:
+        return None, None
+    return img, "L" if is_mono else "RGB"
+
+
+@dataclass
+class CameraCfg:
+    """Configuration for a single camera, used to build subscriptions and log to Rerun."""
+
+    name: str
+    image_topic: str
+    info_topic: str
+
+
+@dataclass
+class Topics:
+    """Grouped ROS topic names for all subscriptions in the visualizer node."""
+
+    robot_description: str
+    joint_states: str
+    forward_commands: Optional[str]
+    action_chunk: str
+    cameras: list[CameraCfg] = field(default_factory=list)
+
+
+class VisualizerNode(Node):
+    """ROS 2 node that subscribes to robot state and camera topics and logs them to Rerun."""
+
+    def __init__(
+        self,
+        topics: Topics,
+        cmd_joint_order: list[str],
+        ee_frame: str,
+        camera_xyz: str,
+        trajectory_color: tuple[int, int, int],
+        viz_max_hz: float = 30.0,
+    ) -> None:
+        """Initialise the node, build subscriptions, and configure Rerun entities.
+
+        Args:
+            topics: Grouped ROS topic names for all subscriptions.
+            cmd_joint_order: Ordered joint names matching ``forward_commands`` array indices.
+            ee_frame: URDF frame used as the end-effector for trajectory FK.
+            camera_xyz: Rerun ``ViewCoordinates`` key (e.g. ``"RDF"``) for camera orientation.
+            trajectory_color: RGB tuple for the predicted action-chunk path overlay.
+            viz_max_hz: Maximum rate (Hz) at which 3D transforms and camera images are
+                sent to Rerun.  Scalar time-series are exempt and always logged at the
+                full joint-state rate.  Raising this increases visual smoothness but
+                also gRPC channel pressure.
+
+        """
+        super().__init__("pai_rerun_visualizer")
+        self._topics = topics
+        self._cmd_joint_order = list(cmd_joint_order)
+        self._ee_frame = ee_frame
+        self._camera_xyz = _VIEW_COORDS.get(camera_xyz.upper(), rr.ViewCoordinates.RDF)
+        self._traj_color = trajectory_color
+        self._viz_min_interval_s: float = 1.0 / max(viz_max_hz, 0.1)
+
+        # Two independent pinocchio models avoid cross-thread state clobbering:
+        # one tracks the live robot pose, the other does trajectory FK.
+        self._model: Optional[RobotModel] = None
+        self._traj_model: Optional[RobotModel] = None
+        self._model_lock = threading.Lock()
+        self._logged_meshes = False
+        self._cam_info: dict[str, tuple[np.ndarray, int, int, str]] = {}
+        self._last_robot_viz_t: float = 0.0  # wall time of last 3D transform log
+        self._last_image_viz_t: dict[str, float] = {}  # per-camera wall time of last image log
+
+        cg = ReentrantCallbackGroup()
+
+        urdf_qos = QoSProfile(
+            depth=1,
+            durability=DurabilityPolicy.TRANSIENT_LOCAL,
+            reliability=ReliabilityPolicy.RELIABLE,
+        )
+        self.create_subscription(
+            String, topics.robot_description, self._on_robot_description, urdf_qos, callback_group=cg
+        )
+        self.create_subscription(
+            JointState, topics.joint_states, self._on_joint_states, qos_profile_sensor_data, callback_group=cg
+        )
+
+        for cam in topics.cameras:
+            self.create_subscription(
+                Image,
+                cam.image_topic,
+                partial(self._on_image, cam_name=cam.name),
+                qos_profile_sensor_data,
+                callback_group=cg,
+            )
+            self.create_subscription(
+                CameraInfo,
+                cam.info_topic,
+                partial(self._on_camera_info, cam_name=cam.name),
+                qos_profile_sensor_data,
+                callback_group=cg,
+            )
+
+        if topics.forward_commands:
+            self.create_subscription(
+                Float64MultiArray,
+                topics.forward_commands,
+                self._on_forward_commands,
+                QoSProfile(depth=10),
+                callback_group=cg,
+            )
+
+        self.create_subscription(
+            JointTrajectory, topics.action_chunk, self._on_action_chunk, QoSProfile(depth=2), callback_group=cg
+        )
+
+        self.get_logger().info("pai_rerun_visualizer started; waiting for robot_description...")
+
+    # -- URDF ----------------------------------------------------------
+    def _on_robot_description(self, msg: String) -> None:
+        """Parse the URDF from the robot_description topic and (re-)build both kinematic models."""
+        try:
+            model = RobotModel(msg.data)
+            traj_model = RobotModel(msg.data)
+        except Exception as exc:
+            self.get_logger().error(f"Failed to build kinematic model from URDF: {exc}")
+            return
+        with self._model_lock:
+            self._model = model
+            self._traj_model = traj_model
+            self._logged_meshes = False
+        self.get_logger().info(
+            f"Built kinematic model: {len(model.visuals)} visual meshes, ee_frame='{self._ee_frame}'"
+            + ("" if model.has_frame(self._ee_frame) else " (NOT found in URDF!)")
+        )
+
+    def _log_static_meshes(self, visuals: list) -> None:
+        """Log visual mesh assets and their static link-to-visual offsets to Rerun.
+
+        Called with a snapshot of the model's visual list captured outside the
+        model lock.  Each mesh is logged as a static ``rr.Asset3D`` under
+        ``robot/<link>/visuals/visual_<i>``, with an optional static
+        ``Transform3D`` for any non-identity ``<origin>`` or non-unit scale.
+
+        Hierarchy::
+
+            robot/<link>                          # dynamic Transform3D (updated by FK)
+            └── robot/<link>/visuals/visual_<i>  # static Asset3D + optional offset
+        """
+        for i, vis in enumerate(visuals):
+            albedo = (vis.color * 255).astype(np.uint8) if vis.color is not None else None
+            rr.log(
+                f"robot/{vis.link}/visuals/visual_{i}",
+                rr.Asset3D(path=vis.mesh_path, albedo_factor=albedo),
+                static=True,
+            )
+            has_offset = not np.allclose(vis.origin, np.eye(4))
+            has_scale = not np.allclose(vis.scale, 1.0)
+            if has_offset or has_scale:
+                rr.log(
+                    f"robot/{vis.link}/visuals/visual_{i}",
+                    rr.Transform3D(
+                        translation=vis.origin[:3, 3],
+                        mat3x3=vis.origin[:3, :3],
+                        scale=vis.scale,
+                    ),
+                    static=True,
+                )
+
+    # -- joint states / robot pose -------------------------------------
+    def _on_joint_states(self, msg: JointState) -> None:
+        """Update joint time series, run FK, and refresh robot pose and camera transforms.
+
+        The model lock is held **only** for FK computation (fast numpy/pinocchio ops).
+        All Rerun I/O runs after the lock is released so that gRPC back-pressure
+        cannot block other callbacks from acquiring the lock.  3D transforms are
+        rate-gated to ``viz_max_hz``; scalar time-series are always logged.
+        """
+        stamp_ns = Time.from_msg(msg.header.stamp).nanoseconds
+        rr.set_time("ros_time", timestamp=np.datetime64(stamp_ns, "ns"))
+
+        name_to_pos = {name: float(msg.position[i]) for i, name in enumerate(msg.name) if i < len(msg.position)}
+        for name, value in name_to_pos.items():
+            rr.log(f"state/position/{name}", rr.Scalars(value))
+
+        # ── FK (fast: pinocchio + numpy) ──────────────────────────────
+        # Capture all results inside the lock; copy arrays so Rerun I/O
+        # can run safely after the lock is released.
+        pending_visuals: list = []
+        link_poses: dict[str, np.ndarray] = {}
+        cam_snapshots: list[tuple] = []
+
+        with self._model_lock:
+            model = self._model
+            if model is None:
+                return
+            if not self._logged_meshes:
+                pending_visuals = list(model.visuals)
+                self._logged_meshes = True
+            model.set_joint_positions(name_to_pos)
+            for vis in model.visuals:
+                if vis.link not in link_poses:
+                    pose = model.frame_pose(vis.link)
+                    if pose is not None:
+                        link_poses[vis.link] = pose.copy()
+            for cam in self._topics.cameras:
+                info = self._cam_info.get(cam.name)
+                if info is None:
+                    continue
+                frame_id = info[3]
+                pose = model.frame_pose(frame_id)
+                if pose is not None:
+                    cam_snapshots.append((cam.name, pose.copy()))
+
+        # ── Rerun I/O (slow: serialise + gRPC) ───────────────────────
+        if pending_visuals:
+            self._log_static_meshes(pending_visuals)
+        # Rate-gate 3D transforms to _VIZ_MAX_HZ.  Scalar plots are exempt
+        # (cheap) and already logged above at the full joint-state rate.
+        _now = time.monotonic()
+        if _now - self._last_robot_viz_t >= self._viz_min_interval_s:
+            self._last_robot_viz_t = _now
+            self._log_robot_pose(link_poses)
+            self._log_cameras(cam_snapshots)
+
+    def _log_robot_pose(self, link_poses: dict[str, np.ndarray]) -> None:
+        """Log world-space link transforms from a pre-computed FK snapshot.
+
+        Accepts a ``{link_name: 4*4_pose}`` dict built inside the model lock
+        and called outside it, so Rerun I/O never delays FK computation.
+        """
+        for link, pose in link_poses.items():
+            rr.log(
+                f"robot/{link}",
+                rr.Transform3D(translation=pose[:3, 3], mat3x3=pose[:3, :3], axis_length=0.03),
+            )
+
+    def _log_cameras(self, cam_snapshots: list[tuple]) -> None:
+        """Log camera extrinsics (world-space Transform3D) from a pre-computed FK snapshot.
+
+        Accepts a list of ``(name, world_T_cam)`` tuples built inside the model
+        lock and called outside it, so Rerun I/O never delays FK computation.
+        Intrinsics (``Pinhole``) are logged once as static data from
+        ``_on_camera_info`` and are not repeated here.
+        """
+        for cam_name, world_t_cam in cam_snapshots:
+            rr.log(
+                f"cameras/{cam_name}",
+                rr.Transform3D(translation=world_t_cam[:3, 3], mat3x3=world_t_cam[:3, :3]),
+            )
+
+    # -- cameras -------------------------------------------------------
+    def _on_camera_info(self, msg: CameraInfo, *, cam_name: str) -> None:
+        """Cache the 3x3 intrinsic matrix, image resolution, and optical frame ID.
+
+        The ``Pinhole`` intrinsics are static (they never change with joint positions)
+        and are logged here once with ``static=True`` so they are not re-sent on
+        every joint-state callback.
+        """
+        k = np.array(msg.k, dtype=float).reshape(3, 3)
+        self._cam_info[cam_name] = (k, msg.width, msg.height, msg.header.frame_id)
+        rr.log(
+            f"cameras/{cam_name}",
+            rr.Pinhole(image_from_camera=k, resolution=[msg.width, msg.height], camera_xyz=self._camera_xyz),
+            static=True,
+        )
+
+    def _on_image(self, msg: Image, *, cam_name: str) -> None:
+        """Decode and log an incoming camera image, rate-gated to ``viz_max_hz``."""
+        stamp_ns = Time.from_msg(msg.header.stamp).nanoseconds
+        img, color_model = image_to_numpy(msg)
+        if img is None:
+            return
+        _now = time.monotonic()
+        if _now - self._last_image_viz_t.get(cam_name, 0.0) < self._viz_min_interval_s:
+            return
+        self._last_image_viz_t[cam_name] = _now
+        rr.set_time("ros_time", timestamp=np.datetime64(stamp_ns, "ns"))
+        rr.log(f"cameras/{cam_name}", rr.Image(img, color_model=color_model))
+
+    # -- forward commands (action plot) --------------------------------
+    def _on_forward_commands(self, msg: Float64MultiArray) -> None:
+        """Log each commanded joint position scalar under ``action/position/<joint>``."""
+        data = list(msg.data)
+        n = min(len(self._cmd_joint_order), len(data))
+        for i in range(n):
+            rr.log(f"action/position/{self._cmd_joint_order[i]}", rr.Scalars(float(data[i])))
+
+    # -- action chunk (predicted 3D trajectory) ------------------------
+    def _on_action_chunk(self, msg: JointTrajectory) -> None:
+        """Convert a predicted action-chunk trajectory into a 3D end-effector path via FK.
+
+        Each waypoint in the ``JointTrajectory`` is run through the dedicated trajectory
+        pinocchio model to obtain the gripper position in world space.  The resulting
+        path is rendered as a fading ``rr.LineStrips3D`` / ``rr.Points3D`` overlay in
+        the 3D scene, with alpha decreasing toward the chunk horizon.
+        """
+        if not msg.points or not msg.joint_names:
+            return
+        with self._model_lock:
+            model = self._traj_model
+            if model is None or not model.has_frame(self._ee_frame):
+                return
+            points: list[np.ndarray] = []
+            for pt in msg.points:
+                name_to_pos = {
+                    name: float(pt.positions[i]) for i, name in enumerate(msg.joint_names) if i < len(pt.positions)
+                }
+                model.set_joint_positions(name_to_pos)
+                pose = model.frame_pose(self._ee_frame)
+                if pose is not None:
+                    points.append(pose[:3, 3].copy())
+
+        if len(points) < 1:
+            return
+        path = np.asarray(points)
+        ts = stamp_to_datetime64(msg.header.stamp) if msg.header.stamp.sec else None
+        if ts is not None:
+            rr.set_time("ros_time", timestamp=ts)
+
+        # Fade alpha from the gripper (opaque) to the chunk horizon (faint).
+        r, g, b = self._traj_color
+        alphas = np.linspace(230, 60, len(path)).astype(np.uint8)
+        colors = np.column_stack([np.full(len(path), r), np.full(len(path), g), np.full(len(path), b), alphas])
+        if len(path) >= 2:  # noqa: PLR2004
+            rr.log("predicted_path", rr.LineStrips3D([path], colors=[[r, g, b, 180]], radii=0.002))
+        rr.log("predicted_path/points", rr.Points3D(path, colors=colors, radii=0.004))
+
+
+def main() -> None:
+    """Entry point for the visualizer node.  Initializes ROS 2 and Rerun, builds the node, and spins."""
+    rclpy.init()
+    bootstrap = Node("pai_rerun_visualizer_params")
+
+    def _declare(node: Node, name: str, default):
+        node.declare_parameter(name, default)
+        return node.get_parameter(name).value
+
+    robot_description = str(_declare(bootstrap, "robot_description_topic", "/robot_description"))
+    joint_states = str(_declare(bootstrap, "joint_states_topic", "/joint_states"))
+    forward_commands = str(_declare(bootstrap, "forward_commands_topic", "/forward_position_controller/commands"))
+    action_chunk = str(_declare(bootstrap, "action_chunk_topic", "/inference/action_chunk"))
+    wrist_image = str(_declare(bootstrap, "wrist_image_topic", "/wrist_camera/image_raw"))
+    wrist_info = str(_declare(bootstrap, "wrist_camera_info_topic", "/wrist_camera/camera_info"))
+    static_image = str(_declare(bootstrap, "static_image_topic", "/static_camera/image_raw"))
+    static_info = str(_declare(bootstrap, "static_camera_info_topic", "/static_camera/camera_info"))
+    ee_frame = str(_declare(bootstrap, "ee_frame", "gripper_frame_link"))
+    camera_xyz = str(_declare(bootstrap, "camera_xyz", "RDF"))
+    cmd_joints = list(
+        _declare(
+            bootstrap,
+            "cmd_joints",
+            [
+                "shoulder_pan_joint",
+                "shoulder_lift_joint",
+                "elbow_flex_joint",
+                "wrist_flex_joint",
+                "wrist_roll_joint",
+                "gripper_joint",
+            ],
+        )
+    )
+    traj_color = list(_declare(bootstrap, "trajectory_color", [0, 255, 0]))
+    viewer = str(_declare(bootstrap, "viewer", "web"))
+    memory_limit = str(_declare(bootstrap, "rerun_memory_limit", "1GB"))
+    viz_max_hz = float(_declare(bootstrap, "viz_max_hz", 30.0))
+    bootstrap.destroy_node()
+
+    rr.init("pai_rerun_visualizer")
+    if viewer == "native":
+        rr.spawn(memory_limit=memory_limit)
+    else:
+        server_uri = rr.serve_grpc(server_memory_limit=memory_limit)
+        rr.serve_web_viewer(connect_to=server_uri)
+
+    blueprint = rrb.Blueprint(
+        rrb.Vertical(
+            rrb.Horizontal(
+                rrb.Spatial3DView(name="3D Scene", origin="/"),
+                rrb.Vertical(
+                    rrb.Spatial2DView(name="Wrist", origin="cameras/cam_wrist"),
+                    rrb.Spatial2DView(name="Overhead", origin="cameras/cam_static"),
+                    row_shares=[1, 1],
+                ),
+                column_shares=[2, 1],
+            ),
+            rrb.Horizontal(
+                rrb.TimeSeriesView(name="State (Joint Positions)", origin="state/position"),
+                rrb.TimeSeriesView(name="Action (Commands)", origin="action/position"),
+                column_shares=[1, 1],
+            ),
+            row_shares=[3, 1],
+        ),
+        auto_layout=False,
+        auto_views=False,
+    )
+    rr.send_blueprint(blueprint)
+
+    topics = Topics(
+        robot_description=robot_description,
+        joint_states=joint_states,
+        forward_commands=forward_commands or None,
+        action_chunk=action_chunk,
+        cameras=[
+            CameraCfg(name="cam_wrist", image_topic=wrist_image, info_topic=wrist_info),
+            CameraCfg(name="cam_static", image_topic=static_image, info_topic=static_info),
+        ],
+    )
+
+    node = VisualizerNode(
+        topics,
+        cmd_joint_order=cmd_joints,
+        ee_frame=ee_frame,
+        camera_xyz=camera_xyz,
+        trajectory_color=(int(traj_color[0]), int(traj_color[1]), int(traj_color[2])),
+        viz_max_hz=viz_max_hz,
+    )
+
+    executor = MultiThreadedExecutor()
+    executor.add_node(node)
+    try:
+        executor.spin()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        executor.shutdown()
+        node.destroy_node()
+        if rclpy.ok():
+            rclpy.shutdown()
+
+
+if __name__ == "__main__":
+    main()

--- a/pai_rerun_visualizer/scripts/visualizer_node
+++ b/pai_rerun_visualizer/scripts/visualizer_node
@@ -1,0 +1,5 @@
+#!/usr/bin/env python3
+from pai_rerun_visualizer.visualizer_node import main
+
+if __name__ == "__main__":
+    main()

--- a/pixi.lock
+++ b/pixi.lock
@@ -11,6 +11,7 @@ environments:
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/_x86_64-microarch-level-1-3_x86_64.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/adwaita-icon-theme-49.0-unix_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/alsa-lib-1.2.15.3-hb03c661_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ampl-asl-1.0.0-h5888daf_2.conda
@@ -49,12 +50,15 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.2.25-hbd8a1cb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cairo-1.18.4-he90730b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/capnproto-1.3.0-h791c776_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/casadi-3.7.2-py312h5f23809_4.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/catkin_pkg-1.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cffi-2.0.0-py312h460c074_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cfgv-3.5.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cfitsio-4.6.3-ha0b56bc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cli11-2.6.2-h54a6638_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cmake-3.31.8-hc85cc9f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/coal-3.0.2-h7900ff3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/coal-python-3.0.2-py312hd6a3311_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-argcomplete-0.3.3-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-bash-0.5.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-cd-0.1.1-pyhd8ed1ab_1.conda
@@ -96,6 +100,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/docutils-0.22.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/double-conversion-3.4.0-hecca717_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/eigen-5.0.1-hc65338a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/eigen-abi-5.0.1.80-hf414acd_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/eigenpy-3.12.0-np2py312hf9833ee_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/elfutils-0.194-h849f50c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/empy-3.3.4-pyh9f0ad1d_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/epoxy-1.5.10-hb03c661_2.conda
@@ -169,6 +175,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/hdf4-4.2.15-h2a13503_7.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/hdf5-1.14.6-nompi_h19486de_108.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/hicolor-icon-theme-0.17-ha770c72_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hpp-fcl-3.0.2-pyh2537366_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/humanfriendly-10.0-pyh707e725_8.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.3-h33c6efd_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/identify-2.6.18-pyhd8ed1ab_0.conda
@@ -205,6 +212,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libattr-2.5.2-hb03c661_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libavif16-1.4.1-hcfa2d63_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.11.0-7_hc00574d_netlib.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libblasfeo-0.1.4.2-h544d10a_100.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libboost-1.88.0-hd24cca6_7.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libboost-devel-1.88.0-hfcd1e18_7.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libboost-headers-1.88.0-ha770c72_7.conda
@@ -218,6 +226,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libccd-double-2.1-h59595ed_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libclang-cpp22.1-22.1.0-default_h99862b1_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libclang13-22.1.0-default_h746c552_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcoal-3.0.2-h969b668_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libcrc32c-1.1.2-h9c3ff4c_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libcups-2.3.3-h7a8fb5f_6.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.19.0-hcf29cc6_0.conda
@@ -229,6 +238,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-hd590300_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libevent-2.1.12-hf998b51_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.7.5-hecca717_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libfatrop-0.0.4-h5888daf_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.5.2-h3435931_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libflac-1.5.0-he200343_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libfreetype-2.14.3-ha770c72_0.conda
@@ -271,6 +281,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgz-common6-6.1.0-hf99613b_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgz-fuel-tools10-10.1.0-h46ff7f1_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgz-gui9-9.0.1-h6313108_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgz-math7-7.5.2-h54a6638_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgz-math8-8.2.0-h54a6638_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgz-msgs11-11.1.0-ha4b349b_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgz-physics8-8.3.0-h5a0d2a0_3.conda
@@ -318,15 +329,19 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-tensorflow-frontend-2025.4.1-h0767aad_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-tensorflow-lite-frontend-2025.4.1-hecca717_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libopus-1.6.1-h280c20c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libosqp-1.0.0-np2py312h1a77e3e_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libpciaccess-0.18-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpinocchio-3.9.0-h54b0c19_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.56-h421ea60_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libpq-18.3-h9abb657_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-6.31.1-h49aed37_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libqdldl-0.1.8-h3f2d84a_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libraw-0.21.5-h074291d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libre2-11-2025.11.05-h7b12aa8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/librsvg-2.62.1-h4c96295_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/librttopo-1.1.0-h46dd2a8_20.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libscotch-7.0.11-int64_hfcc3fd4_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsdformat14-14.8.0-py313h39c33bd_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libsdformat15-15.3.0-py312h1f51ce1_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libsndfile-1.2.2-hc7d488a_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libsodium-1.0.21-h280c20c_3.conda
@@ -407,6 +422,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pcre-8.45-h9c3ff4c_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.47-haa7fec5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pillow-12.1.1-py312h50c33e8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pinocchio-3.9.0-h7900ff3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pinocchio-python-3.9.0-py312h5447bb0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pip-26.0.1-pyh8b19718_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pixman-0.46.4-h54a6638_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pkg-config-0.29.2-h4bc722e_1009.conda
@@ -449,6 +466,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.12-8_cp312.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.3-py312h8a5da7c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/qhull-2020.2-h434a139_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/qhull-static-2020.2-h434a139_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/qt-main-5.15.15-h0c412b5_8.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/qt6-main-6.10.2-pl5321h16c4a6b_6.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/range-v3-0.12.0-h59595ed_0.conda
@@ -793,6 +811,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/rospkg-1.6.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ruby-4.0.2-h95e6935_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/s2n-1.6.2-he8a4886_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.17.1-py312h54fa4ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/sdformat15-15.3.0-hfd474e3_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/sdformat15-python-15.3.0-py312he766b8f_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/sdl2-2.32.56-h54a6638_0.conda
@@ -971,7 +990,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/56/5d/c814546c2333ceea4ba42262d8c4d55763003e767fa169adc693bd524478/requests-2.33.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f5/86/0b9c8f56398b4fc85f8e99279907c258413a297e5603f8f2537fe5806e51/rerun_sdk-0.26.2-cp39-abi3-manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/a0/60/429e9b1cb3fc651937727befe258ea24122d9663e4d5709a48c9cbfceecb/safetensors-0.7.0-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/01/8e/1e35281b8ab6d5d72ebe9911edcdffa3f36b04ed9d51dec6dd140396e220/scipy-1.17.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/cd/1a/b3a3e9f6520493fed7997af4d2de7965d71549c62f994a8fd15f2ecd519e/sentry_sdk-2.56.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c1/d4/59e74daffcb57a07668852eeeb6035af9f32cbfd7a1d2511f17d2fe6a738/smmap-5.0.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a2/09/77d55d46fd61b4a135c444fc97158ef34a095e5681d0a6c10b75bf356191/sympy-1.14.0-py3-none-any.whl
@@ -1028,12 +1046,15 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.2.25-hbd8a1cb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cairo-1.18.4-h0b6afd8_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/capnproto-1.3.0-hf18af32_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/casadi-3.7.2-py312h9feab8c_4.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/catkin_pkg-1.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cffi-2.0.0-py312h1b372e3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cfgv-3.5.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cfitsio-4.6.3-hf475483_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cli11-2.6.2-h7ac5ae9_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cmake-3.31.8-hc9d863e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/coal-3.0.2-h8025657_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/coal-python-3.0.2-py312haf93d54_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-argcomplete-0.3.3-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-bash-0.5.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-cd-0.1.1-pyhd8ed1ab_1.conda
@@ -1075,6 +1096,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/docutils-0.22.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/double-conversion-3.4.0-hfae3067_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/eigen-5.0.1-h5263460_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/eigen-abi-5.0.1.100-h9a8c16c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/eigenpy-3.12.0-np2py312h9df6899_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/elfutils-0.194-h7d8af26_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/empy-3.3.4-pyh9f0ad1d_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/epoxy-1.5.10-he30d5cf_2.conda
@@ -1148,6 +1171,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/hdf4-4.2.15-hb6ba311_7.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/hdf5-1.14.6-nompi_hf95b8e7_108.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/hicolor-icon-theme-0.17-h8af1aa0_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hpp-fcl-3.0.2-pyh2537366_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/humanfriendly-10.0-pyh707e725_8.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/icu-78.3-hcab7f73_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/identify-2.6.18-pyhd8ed1ab_0.conda
@@ -1181,6 +1205,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libattr-2.5.2-he30d5cf_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libavif16-1.4.1-ha599f14_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libblas-3.11.0-7_h0003ede_netlib.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libblasfeo-0.1.4.2-h9f33b5a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libboost-1.88.0-h5651608_7.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libboost-devel-1.88.0-h37bb5a9_7.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libboost-headers-1.88.0-h8af1aa0_7.conda
@@ -1194,6 +1219,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libccd-double-2.1-h2f0025b_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libclang-cpp22.1-22.1.0-default_he95a3c9_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libclang13-22.1.0-default_h94a09a5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcoal-3.0.2-h244ce10_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcrc32c-1.1.2-h01db608_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcups-2.3.3-h4f2b762_6.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcurl-8.19.0-hc57f145_0.conda
@@ -1205,6 +1231,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libev-4.33-h31becfc_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libevent-2.1.12-h4ba1bb4_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libexpat-2.7.5-hfae3067_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libfatrop-0.0.4-h5ad3122_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libffi-3.5.2-h376a255_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libflac-1.5.0-he9c94f4_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libfreetype-2.14.3-h8af1aa0_0.conda
@@ -1247,6 +1274,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgz-common6-6.1.0-h03e062b_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgz-fuel-tools10-10.1.0-hb98d0c0_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgz-gui9-9.0.1-ha9c17c5_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgz-math7-7.5.2-h7ac5ae9_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgz-math8-8.2.0-h7ac5ae9_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgz-msgs11-11.1.0-h3b36bc3_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgz-physics8-8.3.0-ha1467b8_3.conda
@@ -1292,15 +1320,19 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-tensorflow-frontend-2025.4.1-h38473e3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-tensorflow-lite-frontend-2025.4.1-hfae3067_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopus-1.6.1-h80f16a2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libosqp-1.0.0-np2py313ha2de5d4_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libpciaccess-0.18-h86ecc28_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libpinocchio-3.9.0-ha2ac562_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libpng-1.6.56-h1abf092_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libpq-18.3-h7d4fc67_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libprotobuf-6.31.1-h2cf3c76_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libqdldl-0.1.8-h5ad3122_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libraw-0.21.5-h6c2e892_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libre2-11-2025.11.05-h6983b43_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/librsvg-2.62.1-hf685517_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/librttopo-1.1.0-h783d356_20.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libscotch-7.0.11-int64_h6af2d16_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsdformat14-14.8.0-py314h46c0446_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsdformat15-15.3.0-py312h39f64fe_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsndfile-1.2.2-h30591a0_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsodium-1.0.21-h80f16a2_3.conda
@@ -1377,6 +1409,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pcre-8.45-h01db608_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pcre2-10.47-hf841c20_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pillow-12.1.1-py312h3b21937_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pinocchio-3.9.0-h8025657_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pinocchio-python-3.9.0-py312h0d69e1a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pip-26.0.1-pyh8b19718_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pixman-0.46.4-h7ac5ae9_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pkg-config-0.29.2-hce167ba_1009.conda
@@ -1419,6 +1453,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.12-8_cp312.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pyyaml-6.0.3-py312ha4530ae_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/qhull-2020.2-h70be974_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/qhull-static-2020.2-h70be974_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/qt-main-5.15.15-ha9b3be2_8.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/qt6-main-6.10.2-pl5321h598db47_6.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/range-v3-0.12.0-h2f0025b_0.conda
@@ -1763,6 +1798,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/rospkg-1.6.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ruby-4.0.2-h706e587_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/s2n-1.6.2-h35cf281_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/scipy-1.17.1-py312ha7f05e0_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/sdformat15-15.3.0-h1a217ec_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/sdformat15-python-15.3.0-py312hd1fdc56_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/sdl2-2.32.56-h7ac5ae9_0.conda
@@ -1923,7 +1959,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/56/5d/c814546c2333ceea4ba42262d8c4d55763003e767fa169adc693bd524478/requests-2.33.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/13/29/53d8d98799ab32418fd4ba6834d6a5749c31f56160d3c87f52a7219887e9/rerun_sdk-0.26.2-cp39-abi3-manylinux_2_28_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/f1/06/578ffed52c2296f93d7fd2d844cabfa92be51a587c38c8afbb8ae449ca89/safetensors-0.7.0-cp38-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
-      - pypi: https://files.pythonhosted.org/packages/da/34/16f10e3042d2f1d6b66e0428308ab52224b6a23049cb2f5c1756f713815f/scipy-1.17.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/cd/1a/b3a3e9f6520493fed7997af4d2de7965d71549c62f994a8fd15f2ecd519e/sentry_sdk-2.56.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c1/d4/59e74daffcb57a07668852eeeb6035af9f32cbfd7a1d2511f17d2fe6a738/smmap-5.0.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a2/09/77d55d46fd61b4a135c444fc97158ef34a095e5681d0a6c10b75bf356191/sympy-1.14.0-py3-none-any.whl
@@ -1949,6 +1984,7 @@ environments:
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/_x86_64-microarch-level-1-3_x86_64.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/adwaita-icon-theme-49.0-unix_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/alsa-lib-1.2.15.3-hb03c661_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ampl-asl-1.0.0-h5888daf_2.conda
@@ -1987,12 +2023,15 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.2.25-hbd8a1cb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cairo-1.18.4-he90730b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/capnproto-1.3.0-h791c776_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/casadi-3.7.2-py312h5f23809_4.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/catkin_pkg-1.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cffi-2.0.0-py312h460c074_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cfgv-3.5.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cfitsio-4.6.3-ha0b56bc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cli11-2.6.2-h54a6638_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cmake-3.31.8-hc85cc9f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/coal-3.0.2-h7900ff3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/coal-python-3.0.2-py312hd6a3311_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-argcomplete-0.3.3-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-bash-0.5.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-cd-0.1.1-pyhd8ed1ab_1.conda
@@ -2034,6 +2073,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/docutils-0.22.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/double-conversion-3.4.0-hecca717_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/eigen-5.0.1-hc65338a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/eigen-abi-5.0.1.80-hf414acd_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/eigenpy-3.12.0-np2py312hf9833ee_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/elfutils-0.194-h849f50c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/empy-3.3.4-pyh9f0ad1d_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/epoxy-1.5.10-hb03c661_2.conda
@@ -2107,6 +2148,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/hdf4-4.2.15-h2a13503_7.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/hdf5-1.14.6-nompi_h19486de_106.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/hicolor-icon-theme-0.17-ha770c72_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hpp-fcl-3.0.2-pyh2537366_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/humanfriendly-10.0-pyh707e725_8.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.3-h33c6efd_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/identify-2.6.18-pyhd8ed1ab_0.conda
@@ -2143,6 +2185,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libattr-2.5.2-hb03c661_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libavif16-1.4.1-hcfa2d63_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.11.0-7_hc00574d_netlib.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libblasfeo-0.1.4.2-h544d10a_100.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libboost-1.88.0-hd24cca6_7.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libboost-devel-1.88.0-hfcd1e18_7.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libboost-headers-1.88.0-ha770c72_7.conda
@@ -2156,6 +2199,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libccd-double-2.1-h59595ed_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libclang-cpp22.1-22.1.0-default_h99862b1_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libclang13-22.1.0-default_h746c552_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcoal-3.0.2-h969b668_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libcrc32c-1.1.2-h9c3ff4c_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libcups-2.3.3-h7a8fb5f_6.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.19.0-hcf29cc6_0.conda
@@ -2167,6 +2211,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-hd590300_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libevent-2.1.12-hf998b51_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.7.4-hecca717_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libfatrop-0.0.4-h5888daf_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.5.2-h3435931_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libflac-1.5.0-he200343_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libfreetype-2.14.2-ha770c72_0.conda
@@ -2209,6 +2254,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgz-common6-6.1.0-hf99613b_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgz-fuel-tools10-10.1.0-h46ff7f1_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgz-gui9-9.0.1-h6313108_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgz-math7-7.5.2-h54a6638_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgz-math8-8.2.0-h54a6638_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgz-msgs11-11.1.0-ha4b349b_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgz-physics8-8.3.0-h5a0d2a0_3.conda
@@ -2256,15 +2302,19 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-tensorflow-frontend-2025.4.1-h0767aad_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-tensorflow-lite-frontend-2025.4.1-hecca717_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libopus-1.6.1-h280c20c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libosqp-1.0.0-np2py312h1a77e3e_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libpciaccess-0.18-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpinocchio-3.9.0-h54b0c19_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.55-h421ea60_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libpq-18.3-h9abb657_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-6.31.1-h49aed37_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libqdldl-0.1.8-h3f2d84a_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libraw-0.21.5-h074291d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libre2-11-2025.11.05-h7b12aa8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/librsvg-2.62.1-h4c96295_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/librttopo-1.1.0-h46dd2a8_20.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libscotch-7.0.11-int64_hfcc3fd4_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsdformat14-14.8.0-py313h39c33bd_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libsdformat15-15.3.0-py312h1f51ce1_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libsndfile-1.2.2-hc7d488a_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libsodium-1.0.21-h280c20c_3.conda
@@ -2345,6 +2395,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pcre-8.45-h9c3ff4c_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.47-haa7fec5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pillow-12.1.1-py312h50c33e8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pinocchio-3.9.0-h7900ff3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pinocchio-python-3.9.0-py312h5447bb0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pip-26.0.1-pyh8b19718_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pixman-0.46.4-h54a6638_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pkg-config-0.29.2-h4bc722e_1009.conda
@@ -2387,6 +2439,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.12-8_cp312.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.3-py312h8a5da7c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/qhull-2020.2-h434a139_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/qhull-static-2020.2-h434a139_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/qt-main-5.15.15-h0c412b5_8.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/qt6-main-6.10.2-pl5321h16c4a6b_6.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/range-v3-0.12.0-h59595ed_0.conda
@@ -2731,6 +2784,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/rospkg-1.6.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ruby-4.0.2-h95e6935_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/s2n-1.6.2-he8a4886_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.17.1-py312h54fa4ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/sdformat15-15.3.0-hfd474e3_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/sdformat15-python-15.3.0-py312he766b8f_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/sdl2-2.32.56-h54a6638_0.conda
@@ -2908,7 +2962,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f5/86/0b9c8f56398b4fc85f8e99279907c258413a297e5603f8f2537fe5806e51/rerun_sdk-0.26.2-cp39-abi3-manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/a0/60/429e9b1cb3fc651937727befe258ea24122d9663e4d5709a48c9cbfceecb/safetensors-0.7.0-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/01/8e/1e35281b8ab6d5d72ebe9911edcdffa3f36b04ed9d51dec6dd140396e220/scipy-1.17.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/9a/66/20465097782d7e1e742d846407ea7262d338c6e876ddddad38ca8907b38f/sentry_sdk-2.55.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c1/d4/59e74daffcb57a07668852eeeb6035af9f32cbfd7a1d2511f17d2fe6a738/smmap-5.0.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a2/09/77d55d46fd61b4a135c444fc97158ef34a095e5681d0a6c10b75bf356191/sympy-1.14.0-py3-none-any.whl
@@ -2965,12 +3018,15 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.2.25-hbd8a1cb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cairo-1.18.4-h0b6afd8_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/capnproto-1.3.0-hf18af32_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/casadi-3.7.2-py312h9feab8c_4.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/catkin_pkg-1.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cffi-2.0.0-py312h1b372e3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cfgv-3.5.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cfitsio-4.6.3-hf475483_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cli11-2.6.2-h7ac5ae9_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cmake-3.31.8-hc9d863e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/coal-3.0.2-h8025657_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/coal-python-3.0.2-py312haf93d54_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-argcomplete-0.3.3-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-bash-0.5.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-cd-0.1.1-pyhd8ed1ab_1.conda
@@ -3012,6 +3068,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/docutils-0.22.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/double-conversion-3.4.0-hfae3067_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/eigen-5.0.1-h5263460_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/eigen-abi-5.0.1.100-h9a8c16c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/eigenpy-3.12.0-np2py312h9df6899_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/elfutils-0.194-h7d8af26_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/empy-3.3.4-pyh9f0ad1d_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/epoxy-1.5.10-he30d5cf_2.conda
@@ -3085,6 +3143,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/hdf4-4.2.15-hb6ba311_7.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/hdf5-1.14.6-nompi_hf95b8e7_106.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/hicolor-icon-theme-0.17-h8af1aa0_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hpp-fcl-3.0.2-pyh2537366_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/humanfriendly-10.0-pyh707e725_8.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/icu-78.3-hcab7f73_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/identify-2.6.18-pyhd8ed1ab_0.conda
@@ -3118,6 +3177,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libattr-2.5.2-he30d5cf_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libavif16-1.4.1-ha599f14_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libblas-3.11.0-7_h0003ede_netlib.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libblasfeo-0.1.4.2-h9f33b5a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libboost-1.88.0-h5651608_7.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libboost-devel-1.88.0-h37bb5a9_7.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libboost-headers-1.88.0-h8af1aa0_7.conda
@@ -3131,6 +3191,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libccd-double-2.1-h2f0025b_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libclang-cpp22.1-22.1.0-default_he95a3c9_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libclang13-22.1.0-default_h94a09a5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcoal-3.0.2-h244ce10_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcrc32c-1.1.2-h01db608_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcups-2.3.3-h4f2b762_6.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcurl-8.19.0-hc57f145_0.conda
@@ -3142,6 +3203,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libev-4.33-h31becfc_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libevent-2.1.12-h4ba1bb4_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libexpat-2.7.4-hfae3067_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libfatrop-0.0.4-h5ad3122_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libffi-3.5.2-h376a255_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libflac-1.5.0-he9c94f4_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libfreetype-2.14.2-h8af1aa0_0.conda
@@ -3184,6 +3246,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgz-common6-6.1.0-h03e062b_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgz-fuel-tools10-10.1.0-hb98d0c0_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgz-gui9-9.0.1-ha9c17c5_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgz-math7-7.5.2-h7ac5ae9_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgz-math8-8.2.0-h7ac5ae9_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgz-msgs11-11.1.0-h3b36bc3_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgz-physics8-8.3.0-ha1467b8_3.conda
@@ -3229,15 +3292,19 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-tensorflow-frontend-2025.4.1-h38473e3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-tensorflow-lite-frontend-2025.4.1-hfae3067_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopus-1.6.1-h80f16a2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libosqp-1.0.0-np2py313ha2de5d4_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libpciaccess-0.18-h86ecc28_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libpinocchio-3.9.0-ha2ac562_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libpng-1.6.55-h1abf092_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libpq-18.3-h7d4fc67_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libprotobuf-6.31.1-h2cf3c76_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libqdldl-0.1.8-h5ad3122_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libraw-0.21.5-h6c2e892_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libre2-11-2025.11.05-h6983b43_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/librsvg-2.62.1-hf685517_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/librttopo-1.1.0-h783d356_20.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libscotch-7.0.11-int64_h6af2d16_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsdformat14-14.8.0-py314h46c0446_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsdformat15-15.3.0-py312h39f64fe_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsndfile-1.2.2-h30591a0_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsodium-1.0.21-h80f16a2_3.conda
@@ -3314,6 +3381,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pcre-8.45-h01db608_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pcre2-10.47-hf841c20_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pillow-12.1.1-py312h3b21937_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pinocchio-3.9.0-h8025657_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pinocchio-python-3.9.0-py312h0d69e1a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pip-26.0.1-pyh8b19718_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pixman-0.46.4-h7ac5ae9_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pkg-config-0.29.2-hce167ba_1009.conda
@@ -3356,6 +3425,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.12-8_cp312.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pyyaml-6.0.3-py312ha4530ae_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/qhull-2020.2-h70be974_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/qhull-static-2020.2-h70be974_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/qt-main-5.15.15-ha9b3be2_8.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/qt6-main-6.10.2-pl5321h598db47_6.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/range-v3-0.12.0-h2f0025b_0.conda
@@ -3700,6 +3770,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/rospkg-1.6.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ruby-4.0.2-h706e587_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/s2n-1.6.2-h35cf281_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/scipy-1.17.1-py312ha7f05e0_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/sdformat15-15.3.0-h1a217ec_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/sdformat15-python-15.3.0-py312hd1fdc56_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/sdl2-2.32.56-h7ac5ae9_0.conda
@@ -3859,7 +3930,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/13/29/53d8d98799ab32418fd4ba6834d6a5749c31f56160d3c87f52a7219887e9/rerun_sdk-0.26.2-cp39-abi3-manylinux_2_28_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/f1/06/578ffed52c2296f93d7fd2d844cabfa92be51a587c38c8afbb8ae449ca89/safetensors-0.7.0-cp38-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
-      - pypi: https://files.pythonhosted.org/packages/da/34/16f10e3042d2f1d6b66e0428308ab52224b6a23049cb2f5c1756f713815f/scipy-1.17.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/9a/66/20465097782d7e1e742d846407ea7262d338c6e876ddddad38ca8907b38f/sentry_sdk-2.55.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c1/d4/59e74daffcb57a07668852eeeb6035af9f32cbfd7a1d2511f17d2fe6a738/smmap-5.0.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a2/09/77d55d46fd61b4a135c444fc97158ef34a095e5681d0a6c10b75bf356191/sympy-1.14.0-py3-none-any.whl
@@ -3885,6 +3955,7 @@ environments:
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/_x86_64-microarch-level-1-3_x86_64.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/adwaita-icon-theme-49.0-unix_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/alsa-lib-1.2.15.3-hb03c661_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ampl-asl-1.0.0-h5888daf_2.conda
@@ -3923,12 +3994,15 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.2.25-hbd8a1cb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cairo-1.18.4-he90730b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/capnproto-1.3.0-h791c776_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/casadi-3.7.2-py312h5f23809_4.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/catkin_pkg-1.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cffi-2.0.0-py312h460c074_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cfgv-3.5.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cfitsio-4.6.3-ha0b56bc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cli11-2.6.2-h54a6638_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cmake-3.31.8-hc85cc9f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/coal-3.0.2-h7900ff3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/coal-python-3.0.2-py312hd6a3311_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-argcomplete-0.3.3-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-bash-0.5.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-cd-0.1.1-pyhd8ed1ab_1.conda
@@ -3970,6 +4044,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/docutils-0.22.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/double-conversion-3.4.0-hecca717_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/eigen-5.0.1-hc65338a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/eigen-abi-5.0.1.80-hf414acd_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/eigenpy-3.12.0-np2py312hf9833ee_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/elfutils-0.194-h849f50c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/empy-3.3.4-pyh9f0ad1d_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/epoxy-1.5.10-hb03c661_2.conda
@@ -4043,6 +4119,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/hdf4-4.2.15-h2a13503_7.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/hdf5-1.14.6-nompi_h19486de_108.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/hicolor-icon-theme-0.17-ha770c72_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hpp-fcl-3.0.2-pyh2537366_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/humanfriendly-10.0-pyh707e725_8.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.3-h33c6efd_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/identify-2.6.18-pyhd8ed1ab_0.conda
@@ -4079,6 +4156,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libattr-2.5.2-hb03c661_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libavif16-1.4.1-hcfa2d63_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.11.0-7_hc00574d_netlib.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libblasfeo-0.1.4.2-h544d10a_100.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libboost-1.88.0-hd24cca6_7.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libboost-devel-1.88.0-hfcd1e18_7.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libboost-headers-1.88.0-ha770c72_7.conda
@@ -4092,6 +4170,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libccd-double-2.1-h59595ed_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libclang-cpp22.1-22.1.0-default_h99862b1_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libclang13-22.1.0-default_h746c552_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcoal-3.0.2-h969b668_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libcrc32c-1.1.2-h9c3ff4c_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libcups-2.3.3-h7a8fb5f_6.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.19.0-hcf29cc6_0.conda
@@ -4103,6 +4182,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-hd590300_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libevent-2.1.12-hf998b51_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.7.5-hecca717_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libfatrop-0.0.4-h5888daf_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.5.2-h3435931_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libflac-1.5.0-he200343_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libfreetype-2.14.3-ha770c72_0.conda
@@ -4145,6 +4225,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgz-common6-6.1.0-hf99613b_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgz-fuel-tools10-10.1.0-h46ff7f1_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgz-gui9-9.0.1-h6313108_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgz-math7-7.5.2-h54a6638_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgz-math8-8.2.0-h54a6638_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgz-msgs11-11.1.0-ha4b349b_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgz-physics8-8.3.0-h5a0d2a0_3.conda
@@ -4192,15 +4273,19 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-tensorflow-frontend-2025.4.1-h0767aad_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-tensorflow-lite-frontend-2025.4.1-hecca717_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libopus-1.6.1-h280c20c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libosqp-1.0.0-np2py312h1a77e3e_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libpciaccess-0.18-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpinocchio-3.9.0-h54b0c19_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.56-h421ea60_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libpq-18.3-h9abb657_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-6.31.1-h49aed37_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libqdldl-0.1.8-h3f2d84a_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libraw-0.21.5-h074291d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libre2-11-2025.11.05-h7b12aa8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/librsvg-2.62.1-h4c96295_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/librttopo-1.1.0-h46dd2a8_20.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libscotch-7.0.11-int64_hfcc3fd4_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsdformat14-14.8.0-py313h39c33bd_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libsdformat15-15.3.0-py312h1f51ce1_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libsndfile-1.2.2-hc7d488a_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libsodium-1.0.21-h280c20c_3.conda
@@ -4281,6 +4366,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pcre-8.45-h9c3ff4c_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.47-haa7fec5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pillow-12.1.1-py312h50c33e8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pinocchio-3.9.0-h7900ff3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pinocchio-python-3.9.0-py312h5447bb0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pip-26.0.1-pyh8b19718_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pixman-0.46.4-h54a6638_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pkg-config-0.29.2-h4bc722e_1009.conda
@@ -4323,6 +4410,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.12-8_cp312.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.3-py312h8a5da7c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/qhull-2020.2-h434a139_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/qhull-static-2020.2-h434a139_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/qt-main-5.15.15-h0c412b5_8.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/qt6-main-6.10.2-pl5321h16c4a6b_6.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/range-v3-0.12.0-h59595ed_0.conda
@@ -4667,6 +4755,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/rospkg-1.6.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ruby-4.0.2-h95e6935_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/s2n-1.6.2-he8a4886_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.17.1-py312h54fa4ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/sdformat15-15.3.0-hfd474e3_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/sdformat15-python-15.3.0-py312he766b8f_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/sdl2-2.32.56-h54a6638_0.conda
@@ -4845,7 +4934,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/56/5d/c814546c2333ceea4ba42262d8c4d55763003e767fa169adc693bd524478/requests-2.33.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f5/86/0b9c8f56398b4fc85f8e99279907c258413a297e5603f8f2537fe5806e51/rerun_sdk-0.26.2-cp39-abi3-manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/a0/60/429e9b1cb3fc651937727befe258ea24122d9663e4d5709a48c9cbfceecb/safetensors-0.7.0-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/01/8e/1e35281b8ab6d5d72ebe9911edcdffa3f36b04ed9d51dec6dd140396e220/scipy-1.17.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/cd/1a/b3a3e9f6520493fed7997af4d2de7965d71549c62f994a8fd15f2ecd519e/sentry_sdk-2.56.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c1/d4/59e74daffcb57a07668852eeeb6035af9f32cbfd7a1d2511f17d2fe6a738/smmap-5.0.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a2/09/77d55d46fd61b4a135c444fc97158ef34a095e5681d0a6c10b75bf356191/sympy-1.14.0-py3-none-any.whl
@@ -4902,12 +4990,15 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.2.25-hbd8a1cb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cairo-1.18.4-h0b6afd8_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/capnproto-1.3.0-hf18af32_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/casadi-3.7.2-py312h9feab8c_4.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/catkin_pkg-1.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cffi-2.0.0-py312h1b372e3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cfgv-3.5.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cfitsio-4.6.3-hf475483_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cli11-2.6.2-h7ac5ae9_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cmake-3.31.8-hc9d863e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/coal-3.0.2-h8025657_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/coal-python-3.0.2-py312haf93d54_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-argcomplete-0.3.3-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-bash-0.5.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-cd-0.1.1-pyhd8ed1ab_1.conda
@@ -4949,6 +5040,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/docutils-0.22.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/double-conversion-3.4.0-hfae3067_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/eigen-5.0.1-h5263460_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/eigen-abi-5.0.1.100-h9a8c16c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/eigenpy-3.12.0-np2py312h9df6899_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/elfutils-0.194-h7d8af26_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/empy-3.3.4-pyh9f0ad1d_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/epoxy-1.5.10-he30d5cf_2.conda
@@ -5022,6 +5115,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/hdf4-4.2.15-hb6ba311_7.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/hdf5-1.14.6-nompi_hf95b8e7_108.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/hicolor-icon-theme-0.17-h8af1aa0_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hpp-fcl-3.0.2-pyh2537366_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/humanfriendly-10.0-pyh707e725_8.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/icu-78.3-hcab7f73_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/identify-2.6.18-pyhd8ed1ab_0.conda
@@ -5055,6 +5149,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libattr-2.5.2-he30d5cf_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libavif16-1.4.1-ha599f14_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libblas-3.11.0-7_h0003ede_netlib.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libblasfeo-0.1.4.2-h9f33b5a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libboost-1.88.0-h5651608_7.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libboost-devel-1.88.0-h37bb5a9_7.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libboost-headers-1.88.0-h8af1aa0_7.conda
@@ -5068,6 +5163,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libccd-double-2.1-h2f0025b_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libclang-cpp22.1-22.1.0-default_he95a3c9_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libclang13-22.1.0-default_h94a09a5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcoal-3.0.2-h244ce10_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcrc32c-1.1.2-h01db608_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcups-2.3.3-h4f2b762_6.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcurl-8.19.0-hc57f145_0.conda
@@ -5079,6 +5175,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libev-4.33-h31becfc_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libevent-2.1.12-h4ba1bb4_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libexpat-2.7.5-hfae3067_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libfatrop-0.0.4-h5ad3122_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libffi-3.5.2-h376a255_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libflac-1.5.0-he9c94f4_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libfreetype-2.14.3-h8af1aa0_0.conda
@@ -5121,6 +5218,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgz-common6-6.1.0-h03e062b_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgz-fuel-tools10-10.1.0-hb98d0c0_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgz-gui9-9.0.1-ha9c17c5_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgz-math7-7.5.2-h7ac5ae9_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgz-math8-8.2.0-h7ac5ae9_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgz-msgs11-11.1.0-h3b36bc3_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgz-physics8-8.3.0-ha1467b8_3.conda
@@ -5166,15 +5264,19 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-tensorflow-frontend-2025.4.1-h38473e3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-tensorflow-lite-frontend-2025.4.1-hfae3067_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopus-1.6.1-h80f16a2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libosqp-1.0.0-np2py313ha2de5d4_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libpciaccess-0.18-h86ecc28_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libpinocchio-3.9.0-ha2ac562_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libpng-1.6.56-h1abf092_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libpq-18.3-h7d4fc67_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libprotobuf-6.31.1-h2cf3c76_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libqdldl-0.1.8-h5ad3122_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libraw-0.21.5-h6c2e892_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libre2-11-2025.11.05-h6983b43_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/librsvg-2.62.1-hf685517_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/librttopo-1.1.0-h783d356_20.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libscotch-7.0.11-int64_h6af2d16_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsdformat14-14.8.0-py314h46c0446_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsdformat15-15.3.0-py312h39f64fe_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsndfile-1.2.2-h30591a0_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsodium-1.0.21-h80f16a2_3.conda
@@ -5251,6 +5353,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pcre-8.45-h01db608_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pcre2-10.47-hf841c20_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pillow-12.1.1-py312h3b21937_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pinocchio-3.9.0-h8025657_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pinocchio-python-3.9.0-py312h0d69e1a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pip-26.0.1-pyh8b19718_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pixman-0.46.4-h7ac5ae9_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pkg-config-0.29.2-hce167ba_1009.conda
@@ -5293,6 +5397,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.12-8_cp312.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pyyaml-6.0.3-py312ha4530ae_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/qhull-2020.2-h70be974_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/qhull-static-2020.2-h70be974_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/qt-main-5.15.15-ha9b3be2_8.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/qt6-main-6.10.2-pl5321h598db47_6.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/range-v3-0.12.0-h2f0025b_0.conda
@@ -5637,6 +5742,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/rospkg-1.6.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ruby-4.0.2-h706e587_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/s2n-1.6.2-h35cf281_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/scipy-1.17.1-py312ha7f05e0_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/sdformat15-15.3.0-h1a217ec_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/sdformat15-python-15.3.0-py312hd1fdc56_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/sdl2-2.32.56-h7ac5ae9_0.conda
@@ -5797,7 +5903,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/56/5d/c814546c2333ceea4ba42262d8c4d55763003e767fa169adc693bd524478/requests-2.33.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/13/29/53d8d98799ab32418fd4ba6834d6a5749c31f56160d3c87f52a7219887e9/rerun_sdk-0.26.2-cp39-abi3-manylinux_2_28_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/f1/06/578ffed52c2296f93d7fd2d844cabfa92be51a587c38c8afbb8ae449ca89/safetensors-0.7.0-cp38-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
-      - pypi: https://files.pythonhosted.org/packages/da/34/16f10e3042d2f1d6b66e0428308ab52224b6a23049cb2f5c1756f713815f/scipy-1.17.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/cd/1a/b3a3e9f6520493fed7997af4d2de7965d71549c62f994a8fd15f2ecd519e/sentry_sdk-2.56.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c1/d4/59e74daffcb57a07668852eeeb6035af9f32cbfd7a1d2511f17d2fe6a738/smmap-5.0.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a2/09/77d55d46fd61b4a135c444fc97158ef34a095e5681d0a6c10b75bf356191/sympy-1.14.0-py3-none-any.whl
@@ -5840,6 +5945,17 @@ packages:
   purls: []
   size: 28926
   timestamp: 1770939656741
+- conda: https://conda.anaconda.org/conda-forge/noarch/_x86_64-microarch-level-1-3_x86_64.conda
+  build_number: 3
+  sha256: 5f9029eaa78eb13a5499b7a2b012a47a18136b2d41bad99bb7b1796d1fc2b179
+  md5: 225cb2e9b9512730a92f83696b8fbab8
+  depends:
+  - __archspec 1.* x86_64
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 9818
+  timestamp: 1764034326319
 - pypi: https://files.pythonhosted.org/packages/18/a6/907a406bb7d359e6a63f99c313846d9eec4f7e6f7437809e03aa00fa3074/absl_py-2.4.0-py3-none-any.whl
   name: absl-py
   version: 2.4.0
@@ -7055,6 +7171,58 @@ packages:
   purls: []
   size: 4103648
   timestamp: 1773416672155
+- conda: https://conda.anaconda.org/conda-forge/linux-64/casadi-3.7.2-py312h5f23809_4.conda
+  sha256: 7e165d1aa9a3360032068b7c35ed538162ca5175a2a5a84998f0a47ebdd05356
+  md5: 675bd7e865771e0b98cec4cd6dfd766d
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - eigen-abi >=5.0.1.80,<5.0.1.81.0a0
+  - ipopt >=3.14.19,<3.14.20.0a0
+  - libblas >=3.9.0,<4.0a0
+  - libblasfeo >=0.1.4.2,<0.1.5.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libfatrop >=0.0.4,<0.0.5.0a0
+  - libgcc >=14
+  - liblapack >=3.9.0,<4.0a0
+  - libosqp >=1.0.0,<1.0.1.0a0
+  - libstdcxx >=14
+  - mumps-seq >=5.8.2,<5.8.3.0a0
+  - numpy >=1.23,<3
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  - tinyxml2 >=11.0.0,<11.1.0a0
+  license: LGPL-3.0-or-later
+  license_family: LGPL
+  purls:
+  - pkg:pypi/casadi?source=hash-mapping
+  size: 6602590
+  timestamp: 1776838907140
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/casadi-3.7.2-py312h9feab8c_4.conda
+  sha256: 585a82ed49e12e35e243d35b92013406a00102772cdac72ff17be1e9c3f2302f
+  md5: 931bc01c341c2334d969acbf1f416cff
+  depends:
+  - eigen-abi >=5.0.1.100,<5.0.1.101.0a0
+  - ipopt >=3.14.19,<3.14.20.0a0
+  - libblas >=3.9.0,<4.0a0
+  - libblasfeo >=0.1.4.2,<0.1.5.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libfatrop >=0.0.4,<0.0.5.0a0
+  - libgcc >=14
+  - liblapack >=3.9.0,<4.0a0
+  - libosqp >=1.0.0,<1.0.1.0a0
+  - libstdcxx >=14
+  - mumps-seq >=5.8.2,<5.8.3.0a0
+  - numpy >=1.23,<3
+  - python >=3.12,<3.13.0a0
+  - python >=3.12,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
+  - tinyxml2 >=11.0.0,<11.1.0a0
+  license: LGPL-3.0-or-later
+  license_family: LGPL
+  purls:
+  - pkg:pypi/casadi?source=hash-mapping
+  size: 5912785
+  timestamp: 1776839000687
 - conda: https://conda.anaconda.org/conda-forge/noarch/catkin_pkg-1.1.0-pyhd8ed1ab_0.conda
   sha256: fe602164dc1920551e1452543e22338d55d8a879959f12598c9674cf295c6341
   md5: 3e500faf80e42f26d422d849877d48c4
@@ -7239,6 +7407,74 @@ packages:
   purls: []
   size: 20216587
   timestamp: 1757877248575
+- conda: https://conda.anaconda.org/conda-forge/linux-64/coal-3.0.2-h7900ff3_0.conda
+  sha256: f8cce24753a7d4c136db522caec076bc3f66c13e5ba835edde6d13422cf1c6be
+  md5: 8aec2e3568b05bcb58160891e059b09f
+  depends:
+  - coal-python 3.0.2 py312hd6a3311_0
+  - libcoal 3.0.2 h969b668_0
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 8544
+  timestamp: 1759219906765
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/coal-3.0.2-h8025657_0.conda
+  sha256: d3c7b6c43cb7fd27cb5dde867cdf9d35e7d658b900304792bb7d059d7a176f5f
+  md5: 2e8a92a5bc7ab2c22cbfac3d38201a48
+  depends:
+  - coal-python 3.0.2 py312haf93d54_0
+  - libcoal 3.0.2 h244ce10_0
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 8723
+  timestamp: 1759220229332
+- conda: https://conda.anaconda.org/conda-forge/linux-64/coal-python-3.0.2-py312hd6a3311_0.conda
+  sha256: 3482f6cb834597bdc37ecb4646585320a21d465e026ec288179305fba9ab2b02
+  md5: e27aa2284bda5a18ef7d47406efb1d00
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - assimp >=5.4.3,<5.4.4.0a0
+  - eigenpy >=3.12.0,<3.12.1.0a0
+  - libboost >=1.88.0,<1.89.0a0
+  - libboost-python >=1.88.0,<1.89.0a0
+  - libcoal 3.0.2 h969b668_0
+  - libgcc >=14
+  - libstdcxx >=14
+  - numpy >=1.23,<3
+  - octomap >=1.10.0,<1.11.0a0
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  - qhull >=2020.2,<2020.3.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 1389070
+  timestamp: 1759219883397
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/coal-python-3.0.2-py312haf93d54_0.conda
+  sha256: b090059b82e2628ea8ba24c4b1b10713588ad9047c05f2238d56b22a5d02832e
+  md5: b36b43f696be99f28935a95b1f628cab
+  depends:
+  - assimp >=5.4.3,<5.4.4.0a0
+  - eigenpy >=3.12.0,<3.12.1.0a0
+  - libboost >=1.88.0,<1.89.0a0
+  - libboost-python >=1.88.0,<1.89.0a0
+  - libcoal 3.0.2 h244ce10_0
+  - libgcc >=14
+  - libstdcxx >=14
+  - numpy >=1.23,<3
+  - octomap >=1.10.0,<1.11.0a0
+  - python >=3.12,<3.13.0a0
+  - python >=3.12,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
+  - qhull >=2020.2,<2020.3.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 1357637
+  timestamp: 1759220169150
 - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-argcomplete-0.3.3-pyhd8ed1ab_1.conda
   sha256: 05ccb85cad9ca58be9dcb74225f6180a68907a6ab0c990e3940f4decc5bb2280
   md5: bde6042a1b40a2d4021e1becbe8dd84f
@@ -8639,6 +8875,64 @@ packages:
   purls: []
   size: 1311312
   timestamp: 1773745021240
+- conda: https://conda.anaconda.org/conda-forge/linux-64/eigen-abi-5.0.1.80-hf414acd_0.conda
+  sha256: acde70d55f7dbbc043d733427fd6f1ec6ca49db7cbabcf7a656dd29a952b8ad8
+  md5: a85c1768af7780d67c6446c17848b76f
+  constrains:
+  - eigen >=5.0.1,<5.0.2.0a0
+  license: MPL-2.0
+  license_family: MOZILLA
+  purls: []
+  size: 13265
+  timestamp: 1773744756289
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/eigen-abi-5.0.1.100-h9a8c16c_0.conda
+  sha256: dcaa6ebba5f7d0c8d4b7dd55ba00140f308d6332aa31a8aa1c8089e57a9aad15
+  md5: cd37384e3bc4ff609cf3a3953b498ef8
+  constrains:
+  - eigen >=5.0.1,<5.0.2.0a0
+  license: MPL-2.0
+  license_family: MOZILLA
+  purls: []
+  size: 13262
+  timestamp: 1773745021240
+- conda: https://conda.anaconda.org/conda-forge/linux-64/eigenpy-3.12.0-np2py312hf9833ee_3.conda
+  sha256: 7698c8c68ef4a0e7f3ba39e1432a9fd9945e27db36e5c863549c951c5a0f23eb
+  md5: ef30b07b6f131d14c73e809b5098eae6
+  depends:
+  - libboost-python-devel
+  - python
+  - scipy
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - eigen-abi >=5.0.1.80,<5.0.1.81.0a0
+  - libboost-python >=1.88.0,<1.89.0a0
+  - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  license: BSD-2-Clause
+  license_family: BSD
+  purls: []
+  size: 4063356
+  timestamp: 1776071985861
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/eigenpy-3.12.0-np2py312h9df6899_3.conda
+  sha256: 56943ddaed94eaf0d150ee31922eb343c14efdc79694b24bc361b6965c170fb4
+  md5: 5db0394f0a5ef135a915ab6cc81bcc3e
+  depends:
+  - libboost-python-devel
+  - python
+  - scipy
+  - python 3.12.* *_cpython
+  - libstdcxx >=14
+  - libgcc >=14
+  - eigen-abi >=5.0.1.100,<5.0.1.101.0a0
+  - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  - libboost-python >=1.88.0,<1.89.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  purls: []
+  size: 4060234
+  timestamp: 1776071990053
 - pypi: https://files.pythonhosted.org/packages/2a/09/f8d8f8f31e4483c10a906437b4ce31bdf3d6d417b73fe33f1a8b59e34228/einops-0.8.2-py3-none-any.whl
   name: einops
   version: 0.8.2
@@ -11194,6 +11488,18 @@ packages:
   purls: []
   size: 17670
   timestamp: 1771540496764
+- conda: https://conda.anaconda.org/conda-forge/noarch/hpp-fcl-3.0.2-pyh2537366_0.conda
+  sha256: ec0926f80b1a3bad5e62451e2d774a1658ad278d8ba00b48578b59ba5e33a00d
+  md5: 3dbb49ae85936ed1609f479acb1cc154
+  depends:
+  - __unix
+  - coal 3.0.2.*
+  - python >=3.10
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 19962
+  timestamp: 1759224646314
 - pypi: https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl
   name: httpcore
   version: 1.0.9
@@ -12476,6 +12782,28 @@ packages:
   purls: []
   size: 180695
   timestamp: 1763440691147
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libblasfeo-0.1.4.2-h544d10a_100.conda
+  sha256: 4f64c244b1bda8f23deddf3c11f2b3402755a0433da716244a845a31403f329b
+  md5: 4a1612c7202bf04f5ea7a18110739a14
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - _x86_64-microarch-level >=1
+  - libgcc >=13
+  license: BSD-2-Clause
+  license_family: BSD
+  purls: []
+  size: 917774
+  timestamp: 1740067825220
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libblasfeo-0.1.4.2-h9f33b5a_0.conda
+  sha256: 013815e0328ce03942e97ff042ceebbaf5047ec8d7d42feb1223c9c9658bc2df
+  md5: f6d734e5cf298243ac767c900df0f58e
+  depends:
+  - libgcc >=13
+  license: BSD-2-Clause
+  license_family: BSD
+  purls: []
+  size: 736635
+  timestamp: 1740067778830
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libboost-1.88.0-hd24cca6_7.conda
   sha256: dd489228e1916c7720c925248d0ba12803d1dc8b9898be0c51f4ab37bab6ffa5
   md5: d70e4dc6a847d437387d45462fe60cf9
@@ -12843,6 +13171,41 @@ packages:
   purls: []
   size: 12619911
   timestamp: 1772102257387
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcoal-3.0.2-h969b668_0.conda
+  sha256: ca465dc5cbf3f6b24fb273ad751a2187e12535d6225f09546764a0dcbf195bed
+  md5: 3b2a6c0fa4b93a4123786a03bfd4103c
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - assimp >=5.4.3,<5.4.4.0a0
+  - libboost >=1.88.0,<1.89.0a0
+  - libboost-devel
+  - libgcc >=14
+  - libstdcxx >=14
+  - octomap >=1.10.0,<1.11.0a0
+  - qhull >=2020.2,<2020.3.0a0
+  - qhull-static
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 1469302
+  timestamp: 1759219410098
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcoal-3.0.2-h244ce10_0.conda
+  sha256: bee06b303a9f1d4957450ca11f6f6a23f68b870ad881f09cbd08de1e34517eb2
+  md5: 4f1993bb282b6db3b66b1d72c381fc5d
+  depends:
+  - assimp >=5.4.3,<5.4.4.0a0
+  - libboost >=1.88.0,<1.89.0a0
+  - libboost-devel
+  - libgcc >=14
+  - libstdcxx >=14
+  - octomap >=1.10.0,<1.11.0a0
+  - qhull >=2020.2,<2020.3.0a0
+  - qhull-static
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 1447741
+  timestamp: 1759219476559
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libcrc32c-1.1.2-h9c3ff4c_0.tar.bz2
   sha256: fd1d153962764433fe6233f34a72cdeed5dcf8a883a85769e8295ce940b5b0c5
   md5: c965a5aa0d5c1c37ffc62dff36e28400
@@ -13128,6 +13491,31 @@ packages:
   purls: []
   size: 76523
   timestamp: 1774719129371
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libfatrop-0.0.4-h5888daf_1.conda
+  sha256: adfd4320349cf78c44957c77f2359ff4b2cfd3d1b6c40fd3fc009c91567facc8
+  md5: 49137803a38a0ae22ad0289728a15a2c
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libblasfeo >=0.1.4.1,<0.1.5.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  license: LGPL-3.0-or-later
+  license_family: LGPL
+  purls: []
+  size: 241251
+  timestamp: 1736273085602
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libfatrop-0.0.4-h5ad3122_1.conda
+  sha256: a20e465df030e1df70669d763aba802a5d42e1d0019f176dd83526cff6e6f3ff
+  md5: c8ef0ab0d43c63bde7524e632e77f79f
+  depends:
+  - libblasfeo >=0.1.4.1,<0.1.5.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  license: LGPL-3.0-or-later
+  license_family: LGPL
+  purls: []
+  size: 229784
+  timestamp: 1736273122324
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.5.2-h3435931_0.conda
   sha256: 31f19b6a88ce40ebc0d5a992c131f57d919f73c0b92cd1617a5bec83f6e961e6
   md5: a360c33a5abe61c07959e449fa1453eb
@@ -14440,6 +14828,36 @@ packages:
   purls: []
   size: 873238
   timestamp: 1765961995525
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgz-math7-7.5.2-h54a6638_2.conda
+  sha256: fce7eb4797a025c4c61f9502372801bba87ffddc39c68dfbd09f25f30e282c45
+  md5: 27dd93bf04ea4699afedf5ec38758c55
+  depends:
+  - eigen
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - libgz-cmake4 >=4.2.0,<5.0a0
+  - libgz-utils2 >=2.2.1,<3.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  size: 295819
+  timestamp: 1759147748392
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgz-math7-7.5.2-h7ac5ae9_2.conda
+  sha256: 8ad4ffa755ff5024295a3bca949aa8f10122044a2f32ed7eb1890325254e729c
+  md5: 28c93f57cc4ff3228423a6e321831424
+  depends:
+  - eigen
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - libgz-cmake4 >=4.2.0,<5.0a0
+  - libgz-utils2 >=2.2.1,<3.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  size: 297443
+  timestamp: 1759147772705
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libgz-math8-8.2.0-h54a6638_2.conda
   sha256: 604ee7ebac74a45c95ca38152b98984a6ea195ce88e47332bdf397f1ecf3b4b2
   md5: 57644d9cd6fe5cda498611d058ce9197
@@ -15882,6 +16300,33 @@ packages:
   purls: []
   size: 383586
   timestamp: 1768497303687
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libosqp-1.0.0-np2py312h1a77e3e_2.conda
+  sha256: beea43c6cb34d590e936e287b5491b8948947c86261780a753d4a545f60eba72
+  md5: c4396a2e825d384f18244dd34661248f
+  depends:
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libqdldl >=0.1.8,<0.1.9.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  size: 85763
+  timestamp: 1760460227302
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libosqp-1.0.0-np2py313ha2de5d4_2.conda
+  sha256: 437772f4c7d837dd84292144a0898b68ff77c20ea8c440263a1ff45275ac2e0c
+  md5: 80831d50a6a2c83824fa0d86fcab8289
+  depends:
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - libqdldl >=0.1.8,<0.1.9.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  size: 84790
+  timestamp: 1760460229524
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libpciaccess-0.18-hb9d3cd8_0.conda
   sha256: 0bd91de9b447a2991e666f284ae8c722ffb1d84acb594dbd0c031bd656fa32b2
   md5: 70e3400cbbfa03e96dcde7fc13e38c7b
@@ -15903,6 +16348,49 @@ packages:
   purls: []
   size: 29512
   timestamp: 1749901899881
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libpinocchio-3.9.0-h54b0c19_0.conda
+  sha256: fb52cc7da5a55570d394d5ea7abe5e7b8691561315b8c5241fbef77c900499a0
+  md5: 141c59d31e50cffe538d7831643710cd
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - _openmp_mutex >=4.5
+  - casadi >=3.7.0,<3.8.0a0
+  - console_bridge >=1.0.2,<1.1.0a0
+  - hpp-fcl >=3.0.2,<3.0.3.0a0
+  - libboost >=1.88.0,<1.89.0a0
+  - libboost-devel
+  - libgcc >=14
+  - libsdformat14 >=14.8.0,<15.0a0
+  - libstdcxx >=14
+  - qhull >=2020.2,<2020.3.0a0
+  - qhull-static
+  - urdfdom >=4.0.1,<4.1.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  purls: []
+  size: 4577585
+  timestamp: 1767877493855
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libpinocchio-3.9.0-ha2ac562_0.conda
+  sha256: b1c1ffe130cb6c8229663ceb7726d68c9b3a9edb12be15755187f79a65342a9f
+  md5: c21a9051d93ebc921fe60f93ea7bd1a8
+  depends:
+  - _openmp_mutex >=4.5
+  - casadi >=3.7.0,<3.8.0a0
+  - console_bridge >=1.0.2,<1.1.0a0
+  - hpp-fcl >=3.0.2,<3.0.3.0a0
+  - libboost >=1.88.0,<1.89.0a0
+  - libboost-devel
+  - libgcc >=14
+  - libsdformat14 >=14.8.0,<15.0a0
+  - libstdcxx >=14
+  - qhull >=2020.2,<2020.3.0a0
+  - qhull-static
+  - urdfdom >=4.0.1,<4.1.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  purls: []
+  size: 4235531
+  timestamp: 1767877590823
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.55-h421ea60_0.conda
   sha256: 36ade759122cdf0f16e2a2562a19746d96cf9c863ffaa812f2f5071ebbe9c03c
   md5: 5f13ffc7d30ffec87864e678df9957b4
@@ -16001,6 +16489,30 @@ packages:
   purls: []
   size: 4218080
   timestamp: 1766315327959
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libqdldl-0.1.8-h3f2d84a_1.conda
+  sha256: daed72abc320ec9b33a9c7092a160f9683d04425fa194e789829d06528c4b266
+  md5: 3459f613a2c36a161d0cee2f38bfd9d6
+  depends:
+  - libstdcxx >=13
+  - libgcc >=13
+  - __glibc >=2.17,<3.0.a0
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  size: 21954
+  timestamp: 1744008123582
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libqdldl-0.1.8-h5ad3122_1.conda
+  sha256: 5a3e5d96079f175d3e022e245d9340ea4bcd1692325116201acc2d9c6b4c1c97
+  md5: dd76f4b35219f88141db93620ab6cf5a
+  depends:
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  size: 21641
+  timestamp: 1744008367211
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libraw-0.21.5-h074291d_0.conda
   sha256: 7b11ab45e471ba77eab1a21872be3dce8cc81edc2500cd782a6ff49816bce6d4
   md5: c307c91b10217c31fc9d8e18cd58dc64
@@ -16156,6 +16668,42 @@ packages:
   purls: []
   size: 380118
   timestamp: 1771828483074
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libsdformat14-14.8.0-py313h39c33bd_2.conda
+  sha256: e62b01452964fc3c88777088afdfb1ae2b66b00299b1da9380b1c8781de6eca5
+  md5: deb02f1dc8045de577cc3c845ea7849a
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - libgz-math7 >=7.5.2,<8.0a0
+  - libgz-utils2 >=2.2.1,<3.0a0
+  - urdfdom >=4.0.1,<4.1.0a0
+  - libgz-cmake3 >=3.5.5,<4.0a0
+  - tinyxml2 >=11.0.0,<11.1.0a0
+  - libgz-tools >=2.0.3,<3.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  size: 1236957
+  timestamp: 1759339825313
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsdformat14-14.8.0-py314h46c0446_2.conda
+  sha256: 4b1b64e969bf210026eb7662ea48f6da0fa632d1f0f642910679cecf066152ea
+  md5: e32d8fd9e6040c7dc5b4b08bb1380a0e
+  depends:
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - tinyxml2 >=11.0.0,<11.1.0a0
+  - urdfdom >=4.0.1,<4.1.0a0
+  - libgz-tools >=2.0.3,<3.0a0
+  - libgz-utils2 >=2.2.1,<3.0a0
+  - libgz-cmake3 >=3.5.5,<4.0a0
+  - libgz-math7 >=7.5.2,<8.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  size: 1173696
+  timestamp: 1759339860946
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libsdformat15-15.3.0-py312h1f51ce1_3.conda
   sha256: 548e4abe1589149118ac29705792f4f2ba029bcf49b1ba77c575b45df4aad714
   md5: 86617f3d3ac5bba1914a9a403ea36890
@@ -18878,6 +19426,72 @@ packages:
   - pkg:pypi/pillow?source=hash-mapping
   size: 1010426
   timestamp: 1770794010333
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pinocchio-3.9.0-h7900ff3_0.conda
+  sha256: 1e3ce70eb4e4c4941e5d93a13f030d7cac31e10938291c099e6517cc8e3805d3
+  md5: d2a892554678e3abeb89c6aa3a4df761
+  depends:
+  - libpinocchio 3.9.0 h54b0c19_0
+  - pinocchio-python 3.9.0 py312h5447bb0_0
+  - python_abi 3.12.* *_cp312
+  license: BSD-2-Clause
+  license_family: BSD
+  purls: []
+  size: 8978
+  timestamp: 1767880792193
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pinocchio-3.9.0-h8025657_0.conda
+  sha256: 64433792d1b64184893b4e31dd0b57ce6e8e4f20943a007d09087f02d97ab096
+  md5: 4d9c18af21b48da8ff57769374e38a6f
+  depends:
+  - libpinocchio 3.9.0 ha2ac562_0
+  - pinocchio-python 3.9.0 py312h0d69e1a_0
+  - python_abi 3.12.* *_cp312
+  license: BSD-2-Clause
+  license_family: BSD
+  purls: []
+  size: 9092
+  timestamp: 1767881319857
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pinocchio-python-3.9.0-py312h5447bb0_0.conda
+  sha256: 14de65c5590c04435abbf9056f11e0cde25614e939b100ad8a506c8d686d17df
+  md5: 12d1eea644bbe2dbfa7d98fa8fd75978
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - casadi >=3.7.0,<3.8.0a0
+  - eigenpy >=3.12.0,<3.12.1.0a0
+  - hpp-fcl >=3.0.2,<3.0.3.0a0
+  - libboost >=1.88.0,<1.89.0a0
+  - libboost-python >=1.88.0,<1.89.0a0
+  - libgcc >=14
+  - libpinocchio 3.9.0 h54b0c19_0
+  - libstdcxx >=14
+  - numpy >=1.23,<3
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  license: BSD-2-Clause
+  license_family: BSD
+  purls: []
+  size: 10513306
+  timestamp: 1767880732541
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pinocchio-python-3.9.0-py312h0d69e1a_0.conda
+  sha256: 6f01ff4435fd4712b8d5bab04aae855b0fd5bdc034cd7cd63326e061c030b8a7
+  md5: 4deb427080394d8a2962654ee26289e8
+  depends:
+  - casadi >=3.7.0,<3.8.0a0
+  - eigenpy >=3.12.0,<3.12.1.0a0
+  - hpp-fcl >=3.0.2,<3.0.3.0a0
+  - libboost >=1.88.0,<1.89.0a0
+  - libboost-python >=1.88.0,<1.89.0a0
+  - libgcc >=14
+  - libpinocchio 3.9.0 ha2ac562_0
+  - libstdcxx >=14
+  - numpy >=1.23,<3
+  - python >=3.12,<3.13.0a0
+  - python >=3.12,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
+  license: BSD-2-Clause
+  license_family: BSD
+  purls: []
+  size: 10897847
+  timestamp: 1767881260708
 - conda: https://conda.anaconda.org/conda-forge/noarch/pip-26.0.1-pyh8b19718_0.conda
   sha256: 8e1497814a9997654ed7990a79c054ea5a42545679407acbc6f7e809c73c9120
   md5: 67bdec43082fd8a9cffb9484420b39a2
@@ -19952,6 +20566,29 @@ packages:
   purls: []
   size: 554571
   timestamp: 1720813941183
+- conda: https://conda.anaconda.org/conda-forge/linux-64/qhull-static-2020.2-h434a139_5.conda
+  sha256: b02a0e50dd4b5cb619b862c83cde685988c2a6dceb687198ae9ac3cfa8c4c926
+  md5: 0556a8e4d1b88edbf12969718634f3da
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - qhull 2020.2 h434a139_5
+  license: LicenseRef-Qhull
+  purls: []
+  size: 444184
+  timestamp: 1720814041633
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/qhull-static-2020.2-h70be974_5.conda
+  sha256: 3acf9df03342909bd21921b8c05be7d9648f62aaf3c75f7ef2f74a2325577b67
+  md5: 0a0b7ff512c981586c6275171820ac2d
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - qhull 2020.2 h70be974_5
+  license: LicenseRef-Qhull
+  purls: []
+  size: 456306
+  timestamp: 1720813980184
 - conda: https://conda.anaconda.org/conda-forge/linux-64/qt-main-5.15.15-h0c412b5_8.conda
   sha256: c0008c97dbfaef709eff044ea2fdcf7cca55b2e061ff992872d71b9b35f7f91b
   md5: 80e27e7982af989ebc2e0f0d57c75ea7
@@ -35339,94 +35976,51 @@ packages:
   - safetensors[testing] ; extra == 'all'
   - safetensors[all] ; extra == 'dev'
   requires_python: '>=3.9'
-- pypi: https://files.pythonhosted.org/packages/01/8e/1e35281b8ab6d5d72ebe9911edcdffa3f36b04ed9d51dec6dd140396e220/scipy-1.17.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
-  name: scipy
-  version: 1.17.1
-  sha256: 02ae3b274fde71c5e92ac4d54bc06c42d80e399fec704383dcd99b301df37458
-  requires_dist:
-  - numpy>=1.26.4,<2.7
-  - pytest>=8.0.0 ; extra == 'test'
-  - pytest-cov ; extra == 'test'
-  - pytest-timeout ; extra == 'test'
-  - pytest-xdist ; extra == 'test'
-  - asv ; extra == 'test'
-  - mpmath ; extra == 'test'
-  - gmpy2 ; extra == 'test'
-  - threadpoolctl ; extra == 'test'
-  - scikit-umfpack ; extra == 'test'
-  - pooch ; extra == 'test'
-  - hypothesis>=6.30 ; extra == 'test'
-  - array-api-strict>=2.3.1 ; extra == 'test'
-  - cython ; extra == 'test'
-  - meson ; extra == 'test'
-  - ninja ; sys_platform != 'emscripten' and extra == 'test'
-  - sphinx>=5.0.0,<8.2.0 ; extra == 'doc'
-  - intersphinx-registry ; extra == 'doc'
-  - pydata-sphinx-theme>=0.15.2 ; extra == 'doc'
-  - sphinx-copybutton ; extra == 'doc'
-  - sphinx-design>=0.4.0 ; extra == 'doc'
-  - matplotlib>=3.5 ; extra == 'doc'
-  - numpydoc ; extra == 'doc'
-  - jupytext ; extra == 'doc'
-  - myst-nb>=1.2.0 ; extra == 'doc'
-  - pooch ; extra == 'doc'
-  - jupyterlite-sphinx>=0.19.1 ; extra == 'doc'
-  - jupyterlite-pyodide-kernel ; extra == 'doc'
-  - linkify-it-py ; extra == 'doc'
-  - tabulate ; extra == 'doc'
-  - click<8.3.0 ; extra == 'dev'
-  - spin ; extra == 'dev'
-  - mypy==1.10.0 ; extra == 'dev'
-  - typing-extensions ; extra == 'dev'
-  - types-psutil ; extra == 'dev'
-  - pycodestyle ; extra == 'dev'
-  - ruff>=0.12.0 ; extra == 'dev'
-  - cython-lint>=0.12.2 ; extra == 'dev'
-  requires_python: '>=3.11'
-- pypi: https://files.pythonhosted.org/packages/da/34/16f10e3042d2f1d6b66e0428308ab52224b6a23049cb2f5c1756f713815f/scipy-1.17.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl
-  name: scipy
-  version: 1.17.1
-  sha256: e19ebea31758fac5893a2ac360fedd00116cbb7628e650842a6691ba7ca28a21
-  requires_dist:
-  - numpy>=1.26.4,<2.7
-  - pytest>=8.0.0 ; extra == 'test'
-  - pytest-cov ; extra == 'test'
-  - pytest-timeout ; extra == 'test'
-  - pytest-xdist ; extra == 'test'
-  - asv ; extra == 'test'
-  - mpmath ; extra == 'test'
-  - gmpy2 ; extra == 'test'
-  - threadpoolctl ; extra == 'test'
-  - scikit-umfpack ; extra == 'test'
-  - pooch ; extra == 'test'
-  - hypothesis>=6.30 ; extra == 'test'
-  - array-api-strict>=2.3.1 ; extra == 'test'
-  - cython ; extra == 'test'
-  - meson ; extra == 'test'
-  - ninja ; sys_platform != 'emscripten' and extra == 'test'
-  - sphinx>=5.0.0,<8.2.0 ; extra == 'doc'
-  - intersphinx-registry ; extra == 'doc'
-  - pydata-sphinx-theme>=0.15.2 ; extra == 'doc'
-  - sphinx-copybutton ; extra == 'doc'
-  - sphinx-design>=0.4.0 ; extra == 'doc'
-  - matplotlib>=3.5 ; extra == 'doc'
-  - numpydoc ; extra == 'doc'
-  - jupytext ; extra == 'doc'
-  - myst-nb>=1.2.0 ; extra == 'doc'
-  - pooch ; extra == 'doc'
-  - jupyterlite-sphinx>=0.19.1 ; extra == 'doc'
-  - jupyterlite-pyodide-kernel ; extra == 'doc'
-  - linkify-it-py ; extra == 'doc'
-  - tabulate ; extra == 'doc'
-  - click<8.3.0 ; extra == 'dev'
-  - spin ; extra == 'dev'
-  - mypy==1.10.0 ; extra == 'dev'
-  - typing-extensions ; extra == 'dev'
-  - types-psutil ; extra == 'dev'
-  - pycodestyle ; extra == 'dev'
-  - ruff>=0.12.0 ; extra == 'dev'
-  - cython-lint>=0.12.2 ; extra == 'dev'
-  requires_python: '>=3.11'
+- conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.17.1-py312h54fa4ab_1.conda
+  sha256: d5ac05ad45c0d48731eb189c2cbb2bb99f0e3cb7e1acaad373cb2f1f2597fc75
+  md5: 15995ecb2ef890778ba9a3750190f09d
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libgcc >=14
+  - libgfortran
+  - libgfortran5 >=14.3.0
+  - liblapack >=3.9.0,<4.0a0
+  - libstdcxx >=14
+  - numpy <2.7
+  - numpy >=1.23,<3
+  - numpy >=1.25.2
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/scipy?source=compressed-mapping
+  size: 16828243
+  timestamp: 1779874781187
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/scipy-1.17.1-py312ha7f05e0_1.conda
+  sha256: faad223a5a3318687308cd1ae235ad5aee4de2d090cbc2280b3281e506279249
+  md5: 60bbefd5c712570fec2b52275f641192
+  depends:
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libgcc >=14
+  - libgfortran
+  - libgfortran5 >=14.3.0
+  - liblapack >=3.9.0,<4.0a0
+  - libstdcxx >=14
+  - numpy <2.7
+  - numpy >=1.23,<3
+  - numpy >=1.25.2
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/scipy?source=compressed-mapping
+  size: 16878451
+  timestamp: 1779874509446
 - pypi: git+https://github.com/francocipollone/gz-mujoco.git?subdirectory=sdformat_mjcf&branch=francocipollone%2Favoid_eulerseq_compiler#2cb6e69c4a9eb16214508c6db6fc6bf6501cfec4
   name: sdformat-mjcf
   version: 0.1.2

--- a/pixi.toml
+++ b/pixi.toml
@@ -38,6 +38,7 @@ so-arm-leader = { cmd = ["ros2", "launch", "pai_leader_teleop", "leader_bringup.
 so-arm-real = { cmd = ["ros2", "launch", "pai_bringup", "so_arm_real_bringup.launch.py"] }
 so-arm-gz = { cmd = ["ros2", "launch", "pai_bringup", "so_arm_gz_bringup.launch.py"] }
 so-arm-mujoco = { cmd = ["ros2", "launch", "pai_bringup", "so_arm_mujoco_bringup.launch.py"] }
+rerun-viz = { cmd = ["ros2", "launch", "pai_rerun_visualizer", "visualizer.launch.py"] }
 rosetta-record-mujoco = { cmd = [
   "ros2",
   "launch",
@@ -78,6 +79,7 @@ range-v3 = ">=0.12.0,<0.13"
 python = "3.12.*"
 pip = "*"
 numpy = ">=1.26.4,<3"
+pinocchio = "*"
 # Explicitly installing pillow through Conda (rather that letting pip pull it an as transitive dependency)
 # to avoid related issue to: libtiff.so.6: undefined symbol: jpeg12_write_raw_data, version LIBJPEG_8.0.
 pillow = "*"


### PR DESCRIPTION
### Summary

`pai_rerun_visualization`  package: a ROS 2 node that streams the SO-ARM101 robot state into a `Rerun` timeline in real time, covering both the spatial layer (robot mesh, cameras) and the ML layer (joint plots, predicted action-chunk trajectory).

[sim-2026-06-02_17.21.12.webm](https://github.com/user-attachments/assets/840f4673-f9eb-4afd-885e-df2fb72dc3b7)

### Try it locally

It is added (enabled) by default to all the launch files.
```
pixi run so-arm-gz
```

You can disable it via `launch_rerun:=false`  -->  `pixi run so-arm-gz launch_rerun:=false`

### Implementation details

#### Spatial layer

- Robot mesh posed each frame via Pinocchio forward kinematics from /joint_states. 
  - Alternatively we could have relied on /tf tree for updating mesh poses however it is already needed used for chunk projection. (next bullets). So relying directly on this for FK calculation makes it simpler (Just /robot_description and /joint_states topics are needed)

- Camera feeds logged as rr.Image under a rr.Pinhole projection. Intrinsics are logged once as static data from /camera_info; extrinsics are updated each FK step.

- Joint-position time series logged at full joint-state rate.

#### ML layer

- Predicted action-chunk trajectories `(trajectory_msgs/JointTrajectory)` converted to a 3D end-effector path via FK and rendered as a fading `rr.LineStrips3D` extending from the gripper.
  - :exclamation:  A topic is missing to be published via rosetta: (e.g `/inference/action_chunk`) for visualizating this. To be contributed soon: https://github.com/iblnkn/rosetta/pull/29
- Commanded joint positions logged in rerun under action/position/<joint>.
- Observed joint positions logged in rerun under state/position/<joint>.

#### Integration into pai_bringup

 - Added launch_rerun argument (default true) to so_arm_common.launch.py, propagated through all three bringup variants (real, MuJoCo, Gazebo). 
