### PR TITLE
Factor out IK solver from RViz IK example, add Acceleration limit

### DIFF
--- a/pai_rviz_teleop/CMakeLists.txt
+++ b/pai_rviz_teleop/CMakeLists.txt
@@ -6,6 +6,10 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 endif()
 
 find_package(ament_cmake REQUIRED)
+find_package(ament_cmake_python REQUIRED)
+
+# Reusable, RViz-agnostic Python modules (e.g. the differential IK solver).
+ament_python_install_package(${PROJECT_NAME})
 
 install(
   DIRECTORY launch

--- a/pai_rviz_teleop/README.md
+++ b/pai_rviz_teleop/README.md
@@ -14,9 +14,10 @@ The output of the solve is streamed to the `forward_position_controller` (`posit
                                         └────────────────────── /joint_states ◄──────────────────────────────────┘
 ```
 
-1. **Model** — the node subscribes to the latched `/robot_description`, builds a
-   Pinocchio model, and locks every joint except the five arm joints
-   (`shoulder_pan`, `shoulder_lift`, `elbow_flex`, `wrist_flex`, `wrist_roll`).
+1. **Model** — the node subscribes to the latched `/robot_description` and hands
+   it to a `DifferentialIKSolver`, which builds a Pinocchio model and locks every
+   joint except the configured arm joints (by default the SO-ARM101's
+   `shoulder_pan`, `shoulder_lift`, `elbow_flex`, `wrist_flex`, `wrist_roll`).
    The gripper joint is a side branch that does not affect the tool frame, so it
    is excluded from the IK.
 2. **Marker** — once the first `/joint_states` message arrives, a 6-DOF
@@ -24,12 +25,9 @@ The output of the solve is streamed to the `forward_position_controller` (`posit
    where the arm is) in the `world` frame.
 3. **IK loop** — at `control_rate` Hz, the raw marker pose is first passed
    through an SE3 low-pass filter (a geodesic step using Pinocchio's
-   `log6`/`exp6` exponential map) for smoother motion, then a Pink QP is solved:
-   a `FrameTask` pulls the tool frame toward the filtered pose, regularized by a
-   low-weight `PostureTask`. The joint velocity is integrated, clamped to URDF
-   joint limits, and published as a `Float64MultiArray` (the five solved arm
-   joints plus the gripper) in the order the `forward_position_controller`
-   expects.
+   `log6`/`exp6` exponential map) for smoother motion, then handed to the solver.
+   The integrated configuration is published as a `Float64MultiArray`
+   (the solved arm joints plus the gripper) in the order the `forward_position_controller` expects.
 
 ## Marker menu
 
@@ -71,6 +69,8 @@ ros2 topic echo /joint_states
 
 | Parameter                 | Default                                 | Description                                                                                                |
 | ------------------------- | --------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| `arm_joints`              | SO-ARM101 arm joints                    | Ordered joints the IK actuates; all others are locked. Override to drive a different arm.                  |
+| `gripper_joint`           | `gripper_joint`                         | Joint driven by the gripper menu toggle (not part of the IK). Empty string for arms without a gripper.     |
 | `ee_frame`                | `gripper_frame_link`                    | Tool frame driven toward the marker.                                                                       |
 | `root_frame`              | `world`                                 | Model root frame; the marker is anchored here.                                                             |
 | `control_rate`            | `50.0`                                  | IK / command streaming rate (Hz).                                                                          |

--- a/pai_rviz_teleop/README.md
+++ b/pai_rviz_teleop/README.md
@@ -79,6 +79,7 @@ ros2 topic echo /joint_states
 | `posture_cost`            | `1e-3`                                  | PostureTask regularization weight.                                                                         |
 | `lm_damping`              | `1e-2`                                  | FrameTask Levenberg-Marquardt damping; raise to reduce near-singular oscillation.                          |
 | `max_joint_velocity`      | `2.0`                                   | Per-joint velocity cap (rad/s) enforced as a QP constraint; lower for smoother motion.                     |
+| `max_joint_acceleration`  | `10.0`                                  | Per-joint acceleration cap (rad/s²) enforced as a QP constraint; bounds velocity change to smooth jerk.    |
 | `inactivity_timeout`      | `0.3`                                   | Seconds of marker inactivity after which the arm holds and stops republishing (kills steady-state jitter). |
 | `marker_deadband`         | `2e-3`                                  | Min marker pose change (6D log norm) for feedback to count; ignores mouse-down-without-moving.             |
 | `qp_solver`               | `quadprog`                              | QP backend used by Pink.                                                                                   |

--- a/pai_rviz_teleop/package.xml
+++ b/pai_rviz_teleop/package.xml
@@ -13,6 +13,7 @@
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>ament_cmake_python</buildtool_depend>
 
   <exec_depend>controller_manager</exec_depend>
   <exec_depend>geometry_msgs</exec_depend>

--- a/pai_rviz_teleop/pai_rviz_teleop/__init__.py
+++ b/pai_rviz_teleop/pai_rviz_teleop/__init__.py
@@ -1,0 +1,19 @@
+# Copyright (C) 2026 Sebastian Castro
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Reusable teleoperation building blocks for the PAI demos."""
+
+from pai_rviz_teleop.ik_solver import DifferentialIKSolver
+
+__all__ = ["DifferentialIKSolver"]

--- a/pai_rviz_teleop/pai_rviz_teleop/ik_solver.py
+++ b/pai_rviz_teleop/pai_rviz_teleop/ik_solver.py
@@ -43,7 +43,7 @@ import numpy as np
 import pinocchio as pin
 from pink import solve_ik
 from pink.configuration import Configuration
-from pink.limits import ConfigurationLimit, VelocityLimit
+from pink.limits import AccelerationLimit, ConfigurationLimit, VelocityLimit
 from pink.tasks import FrameTask, PostureTask
 
 
@@ -66,6 +66,7 @@ class DifferentialIKSolver:
         posture_cost: float = 1e-3,
         lm_damping: float = 1e-2,
         max_joint_velocity: float = 2.0,
+        max_joint_acceleration: float = 10.0,
         qp_solver: str = "quadprog",
     ):
         """Build the reduced Pinocchio model and the differential IK tasks.
@@ -83,6 +84,10 @@ class DifferentialIKSolver:
                 bounded.
             max_joint_velocity: Per-joint velocity cap (rad/s) enforced as a QP
                 constraint.
+            max_joint_acceleration: Per-joint acceleration cap (rad/s^2) enforced
+                as a QP constraint, bounding how fast the commanded joint
+                velocity may change between ticks (smooths jerk on drag
+                start/stop/reverse).
             qp_solver: QP backend used by Pink (e.g. ``"quadprog"``).
 
         """
@@ -131,9 +136,16 @@ class DifferentialIKSolver:
         # integrated configuration inside the URDF joint position bounds as a
         # proper QP constraint (no post-hoc clamping). The VelocityLimit reads
         # the model's velocityLimit, so override it with the tunable per-joint
-        # cap (the URDF limits are effectively unbounded) before constructing it.
+        # cap (the URDF limits are effectively unbounded) first. The
+        # AccelerationLimit bounds the change in commanded velocity between
+        # ticks, which smooths the jerk on drag start/stop/reverse.
         self.model.velocityLimit[:] = max_joint_velocity
-        self._limits = [ConfigurationLimit(self.model), VelocityLimit(self.model)]
+        self._accel_limit = AccelerationLimit(self.model, np.full(self.model.nv, max_joint_acceleration))
+        self._limits = [ConfigurationLimit(self.model), VelocityLimit(self.model), self._accel_limit]
+
+        # Velocity commanded by the previous solve, fed to the AccelerationLimit
+        # so it can bound the change in velocity.
+        self._last_velocity = np.zeros(self.model.nv)
 
         # Start at the neutral configuration until a frontend seeds it.
         self._q = pin.neutral(self.model)
@@ -163,6 +175,21 @@ class DifferentialIKSolver:
         """Seed the internal configuration (e.g. from measured joint states)."""
         self._q = np.asarray(q, dtype=float)
         self._configuration.update(self._q)
+        # A reset is a discontinuous jump, so the arm is at rest afterward.
+        self.set_zero_velocity()
+
+    def set_zero_velocity(self) -> None:
+        """Mark the arm as stationary (no motion commanded this tick).
+
+        The AccelerationLimit ramps the next solve's velocity from the one we
+        last commanded. On any tick where we command no motion -- a frontend
+        gating the solve while idle, or a failed solve -- the arm holds, so that
+        commanded velocity is zero. Calling this keeps that memory honest, so
+        the arm ramps up from rest on resume instead of lurching from a stale
+        pre-idle velocity (and the QP cannot wedge against an infeasible braking
+        constraint that only a reset would clear).
+        """
+        self._last_velocity = np.zeros(self.model.nv)
 
     def forward_kinematics(self, q: np.ndarray | None = None) -> "pin.SE3":
         """Return the tool-frame pose for ``q`` (defaults to the current one)."""
@@ -209,13 +236,23 @@ class DifferentialIKSolver:
         q = self._q
         self._configuration.update(q)
         self._frame_task.set_target(target_pose)
-        velocity = solve_ik(
-            self._configuration,
-            [self._frame_task, self._posture_task],
-            dt,
-            solver=self.qp_solver,
-            limits=self._limits,
-        )
+        # The AccelerationLimit constrains the new velocity relative to the one
+        # we last commanded, so hand it that velocity each tick.
+        self._accel_limit.set_last_integration(self._last_velocity, dt)
+        try:
+            velocity = solve_ik(
+                self._configuration,
+                [self._frame_task, self._posture_task],
+                dt,
+                solver=self.qp_solver,
+                limits=self._limits,
+            )
+        except Exception:
+            # No motion was commanded, so the arm holds at ``q``: treat this tick
+            # as stationary so the AccelerationLimit can recover next tick.
+            self.set_zero_velocity()
+            raise
+        self._last_velocity = velocity
         q_next = pin.integrate(self.model, q, velocity * dt)
         self._q = q_next
         return q_next

--- a/pai_rviz_teleop/pai_rviz_teleop/ik_solver.py
+++ b/pai_rviz_teleop/pai_rviz_teleop/ik_solver.py
@@ -1,0 +1,221 @@
+# Copyright (C) 2026 Sebastian Castro
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Standalone differential inverse kinematics solver.
+
+This module deliberately knows nothing about ROS, RViz, or any specific robot.
+It wraps a Pinocchio model and the `Pink <https://github.com/stephane-caron/pink>`_
+differential IK QP so that *any* teleoperation frontend (an RViz interactive
+marker, a phone app, a leader arm, a scripted trajectory, ...) can reuse the
+same solve by simply feeding it a target tool pose.
+
+The robot is described entirely by its inputs:
+
+  * ``urdf_xml`` -- the robot description.
+  * ``arm_joints`` -- the ordered list of joints the IK is allowed to actuate.
+    Every other joint in the URDF is locked at its neutral configuration, so the
+    solver is agnostic to the particular arm (the SO-ARM101 is just the default
+    used by the demo node).
+  * ``ee_frame`` -- the tool frame driven toward the target.
+
+Typical usage::
+
+    solver = DifferentialIKSolver(urdf_xml, arm_joints, ee_frame)
+    solver.reset(solver.configuration_from_dict(joint_positions))
+    pose = solver.forward_kinematics()        # current tool pose (SE3)
+    q = solver.solve(target_pose, dt)         # one differential IK step
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pinocchio as pin
+from pink import solve_ik
+from pink.configuration import Configuration
+from pink.limits import ConfigurationLimit, VelocityLimit
+from pink.tasks import FrameTask, PostureTask
+
+
+class DifferentialIKSolver:
+    """Robot- and frontend-agnostic differential IK solver.
+
+    The solver holds the current arm configuration internally. Frontends seed it
+    with :meth:`reset` (typically from measured joint states) and then call
+    :meth:`solve` once per control tick with the desired tool pose.
+    """
+
+    def __init__(
+        self,
+        urdf_xml: str,
+        arm_joints: list[str],
+        ee_frame: str,
+        *,
+        position_cost: float = 0.5,
+        orientation_cost: float = 0.1,
+        posture_cost: float = 1e-3,
+        lm_damping: float = 1e-2,
+        max_joint_velocity: float = 2.0,
+        qp_solver: str = "quadprog",
+    ):
+        """Build the reduced Pinocchio model and the differential IK tasks.
+
+        Args:
+            urdf_xml: The robot description (URDF XML string).
+            arm_joints: Ordered list of joint names the IK may actuate. All
+                other joints are locked at their neutral configuration.
+            ee_frame: Name of the tool frame driven toward the target pose.
+            position_cost: FrameTask position weight.
+            orientation_cost: FrameTask orientation weight.
+            posture_cost: PostureTask regularization weight (rest-pose pull).
+            lm_damping: FrameTask Levenberg-Marquardt damping; regularizes the
+                QP in near-singular directions so commanded velocities stay
+                bounded.
+            max_joint_velocity: Per-joint velocity cap (rad/s) enforced as a QP
+                constraint.
+            qp_solver: QP backend used by Pink (e.g. ``"quadprog"``).
+
+        """
+        self.arm_joints = list(arm_joints)
+        self.ee_frame = ee_frame
+        self.qp_solver = qp_solver
+
+        # Keep the full model so callers can query joint limits of locked joints
+        # (e.g. a gripper) that are not part of the reduced IK model.
+        self.full_model = pin.buildModelFromXML(urdf_xml)
+
+        missing = [j for j in self.arm_joints if not self.full_model.existJointName(j)]
+        if missing:
+            available = [self.full_model.names[jid] for jid in range(1, self.full_model.njoints)]
+            raise ValueError(f"Arm joints {missing} not found in URDF. Available joints: {available}")
+
+        # Lock every joint that is not one of the arm joints so the IK only
+        # actuates ``arm_joints``. Locked joints are pinned at neutral.
+        locked_joint_ids = [
+            jid
+            for jid in range(1, self.full_model.njoints)  # joint 0 is the universe
+            if self.full_model.names[jid] not in self.arm_joints
+        ]
+        q_ref = pin.neutral(self.full_model)
+        self.model = pin.buildReducedModel(self.full_model, locked_joint_ids, q_ref)
+        self.data = self.model.createData()
+
+        if not self.model.existFrame(self.ee_frame):
+            available = [f.name for f in self.model.frames]
+            raise ValueError(f"End-effector frame '{self.ee_frame}' not found in model. Available frames: {available}")
+
+        # Joint names of the reduced model, in configuration-vector order. This
+        # is what frontends use to map joint states into the configuration.
+        self.joint_names = [self.model.names[jid] for jid in range(1, self.model.njoints)]
+
+        # Differential IK tasks. The frame task target is retargeted every solve.
+        self._frame_task = FrameTask(
+            self.ee_frame,
+            position_cost=position_cost,
+            orientation_cost=orientation_cost,
+            lm_damping=lm_damping,
+        )
+        self._posture_task = PostureTask(cost=posture_cost)
+
+        # Limits enforced by the QP solve. The ConfigurationLimit keeps the
+        # integrated configuration inside the URDF joint position bounds as a
+        # proper QP constraint (no post-hoc clamping). The VelocityLimit reads
+        # the model's velocityLimit, so override it with the tunable per-joint
+        # cap (the URDF limits are effectively unbounded) before constructing it.
+        self.model.velocityLimit[:] = max_joint_velocity
+        self._limits = [ConfigurationLimit(self.model), VelocityLimit(self.model)]
+
+        # Start at the neutral configuration until a frontend seeds it.
+        self._q = pin.neutral(self.model)
+        self._configuration = Configuration(self.model, self.data, self._q)
+        # The posture task is a fixed rest-pose regularizer, not retargeted to
+        # the live configuration.
+        self._posture_task.set_target(self._q)
+
+    # ------------------------------------------------------------------
+    # Configuration access
+    # ------------------------------------------------------------------
+    @property
+    def q(self) -> np.ndarray:
+        """The current configuration vector (in ``joint_names`` order)."""
+        return self._q
+
+    def configuration_from_dict(self, positions: dict) -> np.ndarray | None:
+        """Build a configuration vector from a name -> position mapping.
+
+        Returns ``None`` if any arm joint is missing from ``positions``.
+        """
+        if not all(j in positions for j in self.joint_names):
+            return None
+        return np.array([positions[j] for j in self.joint_names])
+
+    def reset(self, q: np.ndarray) -> None:
+        """Seed the internal configuration (e.g. from measured joint states)."""
+        self._q = np.asarray(q, dtype=float)
+        self._configuration.update(self._q)
+
+    def forward_kinematics(self, q: np.ndarray | None = None) -> "pin.SE3":
+        """Return the tool-frame pose for ``q`` (defaults to the current one)."""
+        if q is None:
+            q = self._q
+        else:
+            self._configuration.update(np.asarray(q, dtype=float))
+        return self._configuration.get_transform_frame_to_world(self.ee_frame)
+
+    def joint_position_limits(self, joint_name: str) -> tuple[float, float]:
+        """Return the ``(lower, upper)`` position limits of a URDF joint.
+
+        Looks up the *full* model so limits of locked joints (e.g. a gripper)
+        remain queryable by frontends.
+        """
+        if not self.full_model.existJointName(joint_name):
+            raise ValueError(f"Joint '{joint_name}' not found in URDF.")
+        jid = self.full_model.getJointId(joint_name)
+        qidx = self.full_model.joints[jid].idx_q
+        return (
+            float(self.full_model.lowerPositionLimit[qidx]),
+            float(self.full_model.upperPositionLimit[qidx]),
+        )
+
+    # ------------------------------------------------------------------
+    # Solve
+    # ------------------------------------------------------------------
+    def solve(self, target_pose: "pin.SE3", dt: float) -> np.ndarray:
+        """Run one differential IK step toward ``target_pose``.
+
+        Solves the Pink QP for a joint velocity that drives the tool frame
+        toward ``target_pose`` (subject to configuration and velocity limit
+        constraints), integrates it over ``dt``, and updates the internal
+        configuration.
+
+        Args:
+            target_pose: Desired tool pose (SE3) in the model root frame.
+            dt: Integration timestep in seconds.
+
+        Returns:
+            The new configuration vector (in ``joint_names`` order).
+
+        """
+        q = self._q
+        self._configuration.update(q)
+        self._frame_task.set_target(target_pose)
+        velocity = solve_ik(
+            self._configuration,
+            [self._frame_task, self._posture_task],
+            dt,
+            solver=self.qp_solver,
+            limits=self._limits,
+        )
+        q_next = pin.integrate(self.model, q, velocity * dt)
+        self._q = q_next
+        return q_next

--- a/pai_rviz_teleop/scripts/interactive_ik_node
+++ b/pai_rviz_teleop/scripts/interactive_ik_node
@@ -42,10 +42,6 @@ import pinocchio as pin
 import rclpy
 from geometry_msgs.msg import Pose
 from interactive_markers import InteractiveMarkerServer, MenuHandler
-from pink import solve_ik
-from pink.configuration import Configuration
-from pink.limits import VelocityLimit
-from pink.tasks import FrameTask, PostureTask
 from rclpy.callback_groups import MutuallyExclusiveCallbackGroup
 from rclpy.node import Node
 from rclpy.qos import QoSDurabilityPolicy, QoSHistoryPolicy, QoSProfile, QoSReliabilityPolicy
@@ -58,21 +54,20 @@ from visualization_msgs.msg import (
     Marker,
 )
 
-# The five arm joints solved by the IK, in order. The gripper joint is
-# intentionally excluded (locked) from the IK since it does not move the
-# tool frame.
-ARM_JOINTS = [
+from pai_rviz_teleop.ik_solver import DifferentialIKSolver
+
+# Default arm joints for the SO-ARM101, in order. This is only the node's
+# default for the ``arm_joints`` parameter -- the underlying DifferentialIKSolver
+# is arm-agnostic, so pointing the node at a different robot is just a matter of
+# overriding ``arm_joints`` (and ``gripper_joint``). The gripper joint is
+# intentionally excluded from the IK since it does not move the tool frame.
+DEFAULT_ARM_JOINTS = [
     "shoulder_pan_joint",
     "shoulder_lift_joint",
     "elbow_flex_joint",
     "wrist_flex_joint",
     "wrist_roll_joint",
 ]
-
-# Full joint ordering expected by the forward_position_controller
-# (position_controllers/JointGroupPositionController). The gripper is appended;
-# its value is driven by the menu toggle rather than the IK.
-COMMAND_JOINTS = [*ARM_JOINTS, "gripper_joint"]
 
 
 def transient_local_qos(depth=1):
@@ -91,6 +86,13 @@ class InteractiveIKNode(Node):
     def __init__(self):
         """Initialize parameters, wait for the URDF, and build the IK problem."""
         super().__init__("interactive_ik_node")
+
+        # Robot-specific joint configuration. Defaults target the SO-ARM101 but
+        # can be overridden to drive any arm via the same DifferentialIKSolver.
+        self.declare_parameter("arm_joints", DEFAULT_ARM_JOINTS)
+        # Joint actuated by the gripper menu toggle (not part of the IK). Set to
+        # an empty string for arms without a gripper.
+        self.declare_parameter("gripper_joint", "gripper_joint")
 
         self.declare_parameter("ee_frame", "gripper_frame_link")
         # The marker is anchored in (and its pose interpreted relative to) the
@@ -123,7 +125,7 @@ class InteractiveIKNode(Node):
         self.declare_parameter("marker_deadband", 2e-3)
         # Command topic of the position_controllers/JointGroupPositionController
         # (forward_position_controller). It expects a Float64MultiArray with one
-        # entry per configured joint, in COMMAND_JOINTS order.
+        # entry per configured joint, in self._command_joints order.
         self.declare_parameter("command_topic", "/forward_position_controller/commands")
         self.declare_parameter("qp_solver", "quadprog")
         # Gripper toggle menu: open/closed setpoints (rad) and animation speed.
@@ -135,6 +137,8 @@ class InteractiveIKNode(Node):
         # marker pose, in (0, 1]. 1.0 disables filtering; smaller is smoother.
         self.declare_parameter("target_lowpass_alpha", 0.5)
 
+        self.arm_joints = list(self.get_parameter("arm_joints").value)
+        self.gripper_joint = self.get_parameter("gripper_joint").value or None
         self.ee_frame = self.get_parameter("ee_frame").value
         self.root_frame = self.get_parameter("root_frame").value
         self.control_rate = float(self.get_parameter("control_rate").value)
@@ -175,7 +179,8 @@ class InteractiveIKNode(Node):
 
         # Right-click context menu on the marker.
         self._menu_handler = MenuHandler()
-        self._menu_handler.insert("Toggle gripper (open/close)", callback=self._on_toggle_gripper)
+        if self._has_gripper:
+            self._menu_handler.insert("Toggle gripper (open/close)", callback=self._on_toggle_gripper)
         self._menu_handler.insert("Reset to current joint states", callback=self._on_reset)
 
         # Control loop on its own callback group so it is not starved by
@@ -215,64 +220,43 @@ class InteractiveIKNode(Node):
         return result["urdf"]
 
     def _build_model(self, urdf_xml):
-        """Build the full model, then reduce it to the five arm joints."""
-        full_model = pin.buildModelFromXML(urdf_xml)
-
-        # Clamp the gripper open/closed setpoints to the URDF joint limits so
-        # the toggle never commands past the mechanical range.
-        if full_model.existJointName("gripper_joint"):
-            gid = full_model.getJointId("gripper_joint")
-            qidx = full_model.joints[gid].idx_q
-            lo = float(full_model.lowerPositionLimit[qidx])
-            hi = float(full_model.upperPositionLimit[qidx])
-            self.gripper_open = float(np.clip(self.gripper_open, lo, hi))
-            self.gripper_closed = float(np.clip(self.gripper_closed, lo, hi))
-
-        # Lock every joint that is not one of the arm joints (e.g. the
-        # gripper) so the IK only actuates ARM_JOINTS. The locked joints are
-        # pinned at their neutral configuration.
-        locked_joint_ids = []
-        for jid in range(1, full_model.njoints):  # joint 0 is the universe
-            name = full_model.names[jid]
-            if name not in ARM_JOINTS:
-                locked_joint_ids.append(jid)
-
-        q_ref = pin.neutral(full_model)
-        self.model = pin.buildReducedModel(full_model, locked_joint_ids, q_ref)
-        self.data = self.model.createData()
-
-        if not self.model.existFrame(self.ee_frame):
-            available = [f.name for f in self.model.frames]
-            raise RuntimeError(
-                f"End-effector frame '{self.ee_frame}' not found in model. Available frames: {available}"
-            )
-
-        # The reduced model preserves the arm joints; record their q-index so
-        # we can map /joint_states into the configuration vector.
-        self._model_joint_names = [self.model.names[jid] for jid in range(1, self.model.njoints)]
-        self.get_logger().info(
-            f"Built reduced Pinocchio model with joints {self._model_joint_names} (nq={self.model.nq})."
-        )
-
-        # Differential IK tasks. The frame task is retargeted every tick.
-        self._frame_task = FrameTask(
+        """Build the arm-agnostic IK solver and derive the command joint order."""
+        # All the Pinocchio / Pink machinery lives in the reusable, RViz-agnostic
+        # DifferentialIKSolver. This node is just one frontend (an interactive
+        # marker); the same solver can be driven by any other teleop input.
+        self._solver = DifferentialIKSolver(
+            urdf_xml,
+            self.arm_joints,
             self.ee_frame,
             position_cost=self.position_cost,
             orientation_cost=self.orientation_cost,
+            posture_cost=self.posture_cost,
             lm_damping=self.lm_damping,
+            max_joint_velocity=self.max_joint_velocity,
+            qp_solver=self.qp_solver,
         )
-        self._posture_task = PostureTask(cost=self.posture_cost)
+        # The reduced model preserves the arm joints; this is the order used to
+        # map /joint_states into the configuration vector.
+        self._model_joint_names = self._solver.joint_names
 
-        # Velocity limit enforced by the QP solve. VelocityLimit reads the
-        # model's velocityLimit, so override it with the tunable per-joint cap
-        # before constructing the limit.
-        self.model.velocityLimit[:] = self.max_joint_velocity
-        self._velocity_limit = VelocityLimit(self.model)
+        # Full joint ordering expected by the forward_position_controller
+        # (position_controllers/JointGroupPositionController). The gripper, if
+        # any, is appended; its value is driven by the menu toggle, not the IK.
+        self._command_joints = list(self._model_joint_names)
+        self._has_gripper = self.gripper_joint is not None and self._solver.full_model.existJointName(
+            self.gripper_joint
+        )
+        if self._has_gripper:
+            self._command_joints.append(self.gripper_joint)
+            # Clamp the gripper open/closed setpoints to the URDF joint limits so
+            # the toggle never commands past the mechanical range.
+            lo, hi = self._solver.joint_position_limits(self.gripper_joint)
+            self.gripper_open = float(np.clip(self.gripper_open, lo, hi))
+            self.gripper_closed = float(np.clip(self.gripper_closed, lo, hi))
 
-        # Configuration starts at neutral until the first /joint_states arrives.
-        self._q = pin.neutral(self.model)
-        self._configuration = Configuration(self.model, self.data, self._q)
-        self._posture_task.set_target(self._q)
+        self.get_logger().info(
+            f"Built reduced IK model with joints {self._model_joint_names}; commanding {self._command_joints}."
+        )
 
     # ------------------------------------------------------------------
     # ROS callbacks
@@ -282,8 +266,8 @@ class InteractiveIKNode(Node):
         positions = dict(zip(msg.name, msg.position, strict=False))
         with self._lock:
             self._latest_joint_positions = positions
-            if "gripper_joint" in positions:
-                self._gripper_position = positions["gripper_joint"]
+            if self._has_gripper and self.gripper_joint in positions:
+                self._gripper_position = positions[self.gripper_joint]
             if not self._marker_initialized:
                 self._try_initialize_marker(positions)
 
@@ -292,23 +276,20 @@ class InteractiveIKNode(Node):
 
         Caller must hold ``self._lock``.
         """
-        if not all(j in positions for j in self._model_joint_names):
+        q = self._solver.configuration_from_dict(positions)
+        if q is None:
             return
 
-        q = np.array([positions[j] for j in self._model_joint_names])
-        self._q = q
-        self._configuration.update(q)
-        # NB: the posture task target stays at the neutral pose set in
-        # _build_model -- it is a fixed rest-pose regularizer, not retargeted to
-        # the current configuration.
-
-        tool_pose = self._configuration.get_transform_frame_to_world(self.ee_frame)
+        # Seed the solver from the measured joint states. The posture task stays
+        # at its neutral rest pose -- it is a fixed regularizer, not retargeted
+        # to the current configuration.
+        self._solver.reset(q)
+        tool_pose = self._solver.forward_kinematics()
         self._target_pose = tool_pose.copy()
         self._target_filtered = tool_pose.copy()
-        self._frame_task.set_target(tool_pose)
 
         # Hold the gripper at its measured position until the menu toggles it.
-        self._gripper_cmd = positions.get("gripper_joint", 0.0)
+        self._gripper_cmd = positions.get(self.gripper_joint, 0.0) if self._has_gripper else 0.0
         self._gripper_target = None
 
         self._spawn_marker(tool_pose)
@@ -399,20 +380,20 @@ class InteractiveIKNode(Node):
         """Snap the marker and IK target back to the current joint states."""
         with self._lock:
             positions = self._latest_joint_positions
-            if positions is None or not all(j in positions for j in self._model_joint_names):
+            q = self._solver.configuration_from_dict(positions) if positions else None
+            if q is None:
                 self.get_logger().warn("Reset ignored: joint states not available yet.")
                 return
-            q = np.array([positions[j] for j in self._model_joint_names])
-            self._q = q
-            self._configuration.update(q)
-            tool_pose = self._configuration.get_transform_frame_to_world(self.ee_frame)
+            self._solver.reset(q)
+            tool_pose = self._solver.forward_kinematics()
             self._target_pose = tool_pose.copy()
             self._target_filtered = tool_pose.copy()
             # Mark the marker idle so the arm holds the reset pose instead of
             # resuming the pre-reset jitter.
             self._last_marker_activity = None
             # Stop any in-flight gripper motion and hold the measured position.
-            self._gripper_cmd = positions.get("gripper_joint", self._gripper_cmd)
+            if self._has_gripper:
+                self._gripper_cmd = positions.get(self.gripper_joint, self._gripper_cmd)
             self._gripper_target = None
             pose_msg = self._se3_to_pose(tool_pose)
 
@@ -431,13 +412,13 @@ class InteractiveIKNode(Node):
     def _control_loop(self):
         """Solve differential IK toward the (filtered) marker and stream it.
 
-        The whole tick runs under ``self._lock``. The Pink ``Configuration`` and
-        Pinocchio ``data`` are shared mutable state that menu callbacks (reset)
-        and the marker feedback also touch from other executor threads, so the
-        filter step, solve, integration and ``_q`` write must be atomic with
-        respect to them. Without this, a reset landing mid-solve corrupts the
-        solver data and/or gets clobbered by a stale integrated configuration.
-        The QP solve is sub-millisecond, so holding the lock is cheap.
+        The whole tick runs under ``self._lock``. The DifferentialIKSolver holds
+        shared mutable state (its configuration / Pinocchio data) that menu
+        callbacks (reset) and marker feedback also touch from other executor
+        threads, so the filter step and solve must be atomic with respect to
+        them. Without this, a reset landing mid-solve corrupts the solver data
+        and/or gets clobbered by a stale integrated configuration. The QP solve
+        is sub-millisecond, so holding the lock is cheap.
         """
         dt = 1.0 / self.control_rate
         now = self.get_clock().now()
@@ -459,25 +440,11 @@ class InteractiveIKNode(Node):
                 twist = pin.log6(self._target_filtered.actInv(self._target_pose)).vector
                 self._target_filtered = self._target_filtered * pin.exp6(self.lowpass_alpha * twist)
 
-                q = self._q
-                self._configuration.update(q)
-                self._frame_task.set_target(self._target_filtered)
                 try:
-                    velocity = solve_ik(
-                        self._configuration,
-                        [self._frame_task, self._posture_task],
-                        dt,
-                        solver=self.qp_solver,
-                        limits=[self._velocity_limit],
-                    )
+                    self._solver.solve(self._target_filtered, dt)
                 except Exception as exc:
                     self.get_logger().warn(f"IK solve failed: {exc}", throttle_duration_sec=2.0)
                     return
-
-                q_next = pin.integrate(self.model, q, velocity * dt)
-                # Clamp to joint limits so we never command past the URDF bounds.
-                q_next = np.clip(q_next, self.model.lowerPositionLimit, self.model.upperPositionLimit)
-                self._q = q_next
 
             # Animate the gripper independently of arm motion.
             gripper_before = self._gripper_cmd
@@ -489,7 +456,7 @@ class InteractiveIKNode(Node):
             if not (arm_active or gripper_active):
                 return
 
-            q_cmd = self._q
+            q_cmd = self._solver.q
             gripper = self._gripper_cmd
 
         self._publish_command(q_cmd, gripper)
@@ -515,14 +482,16 @@ class InteractiveIKNode(Node):
         """Publish a Float64MultiArray to the forward_position_controller.
 
         The controller expects one value per configured joint in
-        COMMAND_JOINTS order: the five IK arm joints followed by the gripper,
-        which holds its initial command until the menu toggle animates it.
+        ``self._command_joints`` order: the IK arm joints followed by the
+        gripper (if any), which holds its initial command until the menu toggle
+        animates it.
         """
         q_by_name = dict(zip(self._model_joint_names, q, strict=True))
-        q_by_name["gripper_joint"] = gripper
+        if self._has_gripper:
+            q_by_name[self.gripper_joint] = gripper
 
         cmd = Float64MultiArray()
-        cmd.data = [float(q_by_name[name]) for name in COMMAND_JOINTS]
+        cmd.data = [float(q_by_name[name]) for name in self._command_joints]
         self._command_pub.publish(cmd)
 
     # ------------------------------------------------------------------

--- a/pai_rviz_teleop/scripts/interactive_ik_node
+++ b/pai_rviz_teleop/scripts/interactive_ik_node
@@ -112,6 +112,10 @@ class InteractiveIKNode(Node):
         # solve. The URDF velocity limit is 10 rad/s (effectively unbounded), so
         # this tighter cap is what actually smooths fast/jerky motion.
         self.declare_parameter("max_joint_velocity", 2.0)
+        # Per-joint acceleration cap (rad/s^2) enforced as a QP constraint. Bounds
+        # how fast the commanded joint velocity may change between ticks, which
+        # smooths the snap when a drag starts, stops, or reverses.
+        self.declare_parameter("max_joint_acceleration", 10.0)
         # Marker-inactivity timeout (s). Once no drag feedback has arrived for
         # this long, the arm is considered idle: the loop stops solving and
         # republishing so the controller just holds the last setpoint. This
@@ -147,6 +151,7 @@ class InteractiveIKNode(Node):
         self.posture_cost = float(self.get_parameter("posture_cost").value)
         self.lm_damping = float(self.get_parameter("lm_damping").value)
         self.max_joint_velocity = float(self.get_parameter("max_joint_velocity").value)
+        self.max_joint_acceleration = float(self.get_parameter("max_joint_acceleration").value)
         self.inactivity_timeout = float(self.get_parameter("inactivity_timeout").value)
         self.marker_deadband = float(self.get_parameter("marker_deadband").value)
         self.qp_solver = self.get_parameter("qp_solver").value
@@ -233,6 +238,7 @@ class InteractiveIKNode(Node):
             posture_cost=self.posture_cost,
             lm_damping=self.lm_damping,
             max_joint_velocity=self.max_joint_velocity,
+            max_joint_acceleration=self.max_joint_acceleration,
             qp_solver=self.qp_solver,
         )
         # The reduced model preserves the arm joints; this is the order used to
@@ -445,6 +451,11 @@ class InteractiveIKNode(Node):
                 except Exception as exc:
                     self.get_logger().warn(f"IK solve failed: {exc}", throttle_duration_sec=2.0)
                     return
+            else:
+                # Idle: we command no arm motion, so tell the solver it is
+                # stationary. The AccelerationLimit then ramps from rest when
+                # tracking resumes, instead of lurching from a stale velocity.
+                self._solver.set_zero_velocity()
 
             # Animate the gripper independently of arm motion.
             gripper_before = self._gripper_cmd


### PR DESCRIPTION
Implements the feedback from @francocipollone in #64, plus adds a Pink `AccelerationLimit` constraint to the solver to fix a lot of the jerkiness I was seeing in MuJoCo.

Closes https://github.com/ros-physical-ai/demos/issues/64