### PR TITLE
Update Feetech and SO-ARM driver repos to ros-physical-ai org

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,11 +78,13 @@ source ~/ws_pai/install/setup.bash
 
 | Source                                                                                                            | Description                                                                           |
 | ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
-| [ros2_so_arm](https://github.com/JafarAbdi/ros2_so_arm)                                                           | URDF descriptions, MoveIt config, Gazebo support, and utilities for the SO-ARM robots |
-| [feetech_ros2_driver](https://github.com/legalaspro/feetech_ros2_driver)                                          | ros2_control hardware interface for Feetech servo motors                              |
+| [ros2_so_arm](https://github.com/ros-physical-ai/ros2_so_arm)                                                     | URDF descriptions, MoveIt config, Gazebo support, and utilities for the SO-ARM robots |
+| [feetech_ros2_driver](https://github.com/ros-physical-ai/feetech_ros2_driver)                                     | ros2_control hardware interface for Feetech servo motors                              |
 | [mujoco_ros2_control](https://github.com/ros-controls/mujoco_ros2_control)                                        | ros2_control integration with the MuJoCo physics simulator                            |
 | [rosetta](https://github.com/iblnkn/rosetta) / [rosetta_interfaces](https://github.com/iblnkn/rosetta_interfaces) | ROS 2–LeRobot bridge for recording demonstration datasets                             |
 | [lerobot-robot-rosetta](https://github.com/iblnkn/lerobot-robot-rosetta)                                          | LeRobot Robot plugin for Rosetta — bridges ROS 2 topics to LeRobot's Robot interface  |
+
+We would like to acknowledge the great work of [JafarAbdi](https://github.com/JafarAbdi) in creating ROS 2 drivers for the SO-ARM robots, and transferring his repositories to the `ros-physical-ai` organization.
 
 ## Launching the SO-ARM101
 

--- a/pai.repos
+++ b/pai.repos
@@ -1,12 +1,12 @@
 repositories:
   SO-ARM100/ros2_so_arm100:
     type: git
-    url: https://github.com/JafarAbdi/ros2_so_arm.git
+    url: https://github.com/ros-physical-ai/ros2_so_arm.git
     version: 12fbcb8cf30da7c3d679db384c43765ea311eb18
   SO-ARM100/feetech_ros2_driver:
     type: git
-    url: https://github.com/legalaspro/feetech_ros2_driver.git
-    version: feat/joint-config-and-calibration
+    url: https://github.com/ros-physical-ai/feetech_ros2_driver.git
+    version: 2034e76f7f26c0bd2972ef52642a4e9e9356e7d4
   mujoco_ros2_control:
     type: git
     url: https://github.com/ros-controls/mujoco_ros2_control.git


### PR DESCRIPTION
Also updates the Feetech repo back upstream since https://github.com/ros-physical-ai/feetech_ros2_driver/pull/27 merged since last update