### PR TITLE
Add phone teleoperation

### DIFF
--- a/pai_phone_teleop/CMakeLists.txt
+++ b/pai_phone_teleop/CMakeLists.txt
@@ -8,7 +8,6 @@ endif()
 find_package(ament_cmake REQUIRED)
 find_package(ament_cmake_python REQUIRED)
 
-# Install the inner Python package (ee_pose_publisher module).
 ament_python_install_package(${PROJECT_NAME})
 
 install(

--- a/pai_phone_teleop/CMakeLists.txt
+++ b/pai_phone_teleop/CMakeLists.txt
@@ -1,0 +1,25 @@
+cmake_minimum_required(VERSION 3.22)
+project(pai_phone_teleop)
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+find_package(ament_cmake REQUIRED)
+find_package(ament_cmake_python REQUIRED)
+
+# Install the inner Python package (ee_pose_publisher module).
+ament_python_install_package(${PROJECT_NAME})
+
+install(
+  DIRECTORY launch
+  DESTINATION share/${PROJECT_NAME}
+)
+
+install(
+  PROGRAMS
+    scripts/phone_teleop_node
+  DESTINATION lib/${PROJECT_NAME}
+)
+
+ament_package()

--- a/pai_phone_teleop/README.md
+++ b/pai_phone_teleop/README.md
@@ -2,51 +2,65 @@
 
 Phone-based 6-DoF pose teleoperation for the SO-ARM101.
 
-This package wraps the upstream [`teleop`](https://github.com/SpesRobotics/teleop)
-`python3 -m teleop.ros2` WebXR bridge and supplies it with the end-effector's
-current pose via the `ee_pose_publisher` node.
-
-## Status
-
-This iteration publishes the EE current pose and runs the phone bridge.
-Driving the arm from the phone-published target is **out of scope** and
-will be added in a future iteration.
+A single ROS 2 node embeds the upstream [`teleop`](https://github.com/SpesRobotics/teleop)
+WebXR bridge together with Pinocchio forward kinematics and Pink differential
+IK. The arm tracks the phone's 6-DoF pose in real time by streaming joint
+positions to the `forward_position_controller`.
 
 ## How to run
 
 1. Launch any `pai_bringup` bringup (real / mujoco / gz), e.g.:
 
    ```bash
-   ros2 launch pai_bringup so_arm_mujoco_bringup.launch.py
+   pixi run so-arm-gz
    ```
 
 2. Launch the phone teleop:
 
    ```bash
-   ros2 launch pai_phone_teleop phone_teleop.launch.py
+   pixi run so-arm-phone-ik
    ```
 
-3. Open the URL logged to stdout (default `http://<host>:4443/`) on a
-   phone with a WebXR-capable browser (e.g. Chrome on Android). Hold the
-   phone in the WebXR "natural orientation" (screen up, camera toward you)
-   and press the **Move** button on screen to begin streaming.
+3. Open the HTTPS URL logged to stdout (default `https://<host>:4443/`) on a
+   phone with a WebXR-capable browser (e.g. Chrome on Android).
+
+
+4. Press `START` button for initiating the teleoperation and keep press the `HOLD TO MOVE` button while moving the phone to teleoperate.
+    >[!NOTE]Recommendation: Keep the phone >vertical and steady and then press `START`.
+
+    >[!Important] When you press the start button the XR localization starts using the orientation registered at initialization. If you press START while holding the phone in a weird orientation it might be tricky to start teleoperating correctly as it is easy to get confused.
+
+## Controls
+
+| Control | Action |
+|---|---|
+| **Move** button (hold) | Streams phone pose; arm tracks via differential IK |
+| **A** button (hold) | Gripper opens slowly |
+| **B** button (hold) | Gripper closes slowly |
+| **Gripper** button (toggle) | Engage: locks gripper at position 0 (apply pressure). Disengage: releases A/B control |
+
+The gripper engage button takes priority over A/B — A and B are ignored while
+the gripper is engaged.
 
 ## Topics
 
 | Topic | Direction | Type | Notes |
 |---|---|---|---|
-| `/current_pose` | Publishes | `geometry_msgs/PoseStamped` | EE pose in `base_link` frame, computed from `/joint_states` FK. Consumed by `teleop.ros2`. |
-| `/target_frame` | Subscribes (deferred) | `geometry_msgs/PoseStamped` | Published by `teleop.ros2`. Will be consumed in a future iteration to drive the arm. |
-| `/tf` | Publishes (`teleop_target`) | `tf2_msgs/TFMessage` | `base_link -> teleop_target`, published by `teleop.ros2` for RViz visualization. |
+| `/joint_states` | Subscribes | `sensor_msgs/JointState` | Arm and gripper positions used to seed the IK solver. |
+| `/robot_description` | Subscribes | `std_msgs/String` | Latched URDF, used to build the Pinocchio model at startup. |
+| `teleop_target` | Publishes | `geometry_msgs/PoseStamped` | Phone-commanded EE target in `root_frame`, for RViz. |
+| `/tf` | Publishes | `tf2_msgs/TFMessage` | `root_frame → teleop_target` transform for RViz visualization. |
+| `/forward_position_controller/commands` | Publishes | `std_msgs/Float64MultiArray` | Arm + gripper joint positions at `control_rate` Hz. |
 
-## Known limitations
+## Key parameters
 
-- `teleop.ros2` hard-codes the published `target_frame` `frame_id` to
-  `"link_base"` (likely a typo in the upstream library). The TF broadcaster
-  uses the correct `base_link`. Downstream consumers should rely on the
-  TF or remap/override the frame_id.
-- The `omit_current_pose` launch argument is declared but not yet wired
-  into the `teleop.ros2` command; we always run without the flag, which
-  is the documented correct default (use `/current_pose` as the seed).
-- Gripper mapping is not supported by upstream `teleop.ros2`. Use
-  `teleop.ros2_ik` for that, or wait for the future iteration.
+| Parameter | Default | Description |
+|---|---|---|
+| `host` | `0.0.0.0` | Bind address for the WebXR server. |
+| `port` | `4443` | Port for the WebXR server. |
+| `ee_frame` | `gripper_frame_link` | End-effector frame for FK and IK. |
+| `root_frame` | `base_link` | Reference frame for teleop deltas and visualization. |
+| `control_rate` | `50.0` | IK solve and command publish rate (Hz). |
+| `inactivity_timeout` | `0.3` | Seconds of phone stillness before IK halts. |
+| `gripper_open_speed` | `5.0` | Gripper ramping speed while A/B is held (rad/s). |
+| `command_topic` | `/forward_position_controller/commands` | Joint command topic. |

--- a/pai_phone_teleop/README.md
+++ b/pai_phone_teleop/README.md
@@ -29,9 +29,11 @@ positions to the `forward_position_controller`.
 
 4. Press `START` button for initiating the teleoperation and keep press the `HOLD TO MOVE` button while moving the phone to teleoperate.
 
-   > [!NOTE]Recommendation: Keep the phone >vertical and steady and then press `START`.
+> [!NOTE]
+> Recommendation: Keep the phone >vertical and steady and then press `START`.
 
-   > [!Important] When you press the start button the XR localization starts using the orientation registered at initialization. If you press START while holding the phone in a weird orientation it might be tricky to start teleoperating correctly as it is easy to get confused.
+> [!IMPORTANT]
+> When you press the start button the XR localization starts using the orientation registered at initialization. If you press START while holding the phone in a weird orientation it might be tricky to start teleoperating correctly as it is easy to get confused.
 
 ## Controls
 

--- a/pai_phone_teleop/README.md
+++ b/pai_phone_teleop/README.md
@@ -24,19 +24,19 @@ positions to the `forward_position_controller`.
 3. Open the HTTPS URL logged to stdout (default `https://<host>:4443/`) on a
    phone with a WebXR-capable browser (e.g. Chrome on Android).
 
-
 4. Press `START` button for initiating the teleoperation and keep press the `HOLD TO MOVE` button while moving the phone to teleoperate.
-    >[!NOTE]Recommendation: Keep the phone >vertical and steady and then press `START`.
 
-    >[!Important] When you press the start button the XR localization starts using the orientation registered at initialization. If you press START while holding the phone in a weird orientation it might be tricky to start teleoperating correctly as it is easy to get confused.
+   > [!NOTE]Recommendation: Keep the phone >vertical and steady and then press `START`.
+
+   > [!Important] When you press the start button the XR localization starts using the orientation registered at initialization. If you press START while holding the phone in a weird orientation it might be tricky to start teleoperating correctly as it is easy to get confused.
 
 ## Controls
 
-| Control | Action |
-|---|---|
-| **Move** button (hold) | Streams phone pose; arm tracks via differential IK |
-| **A** button (hold) | Gripper opens slowly |
-| **B** button (hold) | Gripper closes slowly |
+| Control                     | Action                                                                                |
+| --------------------------- | ------------------------------------------------------------------------------------- |
+| **Move** button (hold)      | Streams phone pose; arm tracks via differential IK                                    |
+| **A** button (hold)         | Gripper opens slowly                                                                  |
+| **B** button (hold)         | Gripper closes slowly                                                                 |
 | **Gripper** button (toggle) | Engage: locks gripper at position 0 (apply pressure). Disengage: releases A/B control |
 
 The gripper engage button takes priority over A/B — A and B are ignored while
@@ -44,23 +44,23 @@ the gripper is engaged.
 
 ## Topics
 
-| Topic | Direction | Type | Notes |
-|---|---|---|---|
-| `/joint_states` | Subscribes | `sensor_msgs/JointState` | Arm and gripper positions used to seed the IK solver. |
-| `/robot_description` | Subscribes | `std_msgs/String` | Latched URDF, used to build the Pinocchio model at startup. |
-| `teleop_target` | Publishes | `geometry_msgs/PoseStamped` | Phone-commanded EE target in `root_frame`, for RViz. |
-| `/tf` | Publishes | `tf2_msgs/TFMessage` | `root_frame → teleop_target` transform for RViz visualization. |
-| `/forward_position_controller/commands` | Publishes | `std_msgs/Float64MultiArray` | Arm + gripper joint positions at `control_rate` Hz. |
+| Topic                                   | Direction  | Type                         | Notes                                                          |
+| --------------------------------------- | ---------- | ---------------------------- | -------------------------------------------------------------- |
+| `/joint_states`                         | Subscribes | `sensor_msgs/JointState`     | Arm and gripper positions used to seed the IK solver.          |
+| `/robot_description`                    | Subscribes | `std_msgs/String`            | Latched URDF, used to build the Pinocchio model at startup.    |
+| `teleop_target`                         | Publishes  | `geometry_msgs/PoseStamped`  | Phone-commanded EE target in `root_frame`, for RViz.           |
+| `/tf`                                   | Publishes  | `tf2_msgs/TFMessage`         | `root_frame → teleop_target` transform for RViz visualization. |
+| `/forward_position_controller/commands` | Publishes  | `std_msgs/Float64MultiArray` | Arm + gripper joint positions at `control_rate` Hz.            |
 
 ## Key parameters
 
-| Parameter | Default | Description |
-|---|---|---|
-| `host` | `0.0.0.0` | Bind address for the WebXR server. |
-| `port` | `4443` | Port for the WebXR server. |
-| `ee_frame` | `gripper_frame_link` | End-effector frame for FK and IK. |
-| `root_frame` | `base_link` | Reference frame for teleop deltas and visualization. |
-| `control_rate` | `50.0` | IK solve and command publish rate (Hz). |
-| `inactivity_timeout` | `0.3` | Seconds of phone stillness before IK halts. |
-| `gripper_open_speed` | `5.0` | Gripper ramping speed while A/B is held (rad/s). |
-| `command_topic` | `/forward_position_controller/commands` | Joint command topic. |
+| Parameter            | Default                                 | Description                                          |
+| -------------------- | --------------------------------------- | ---------------------------------------------------- |
+| `host`               | `0.0.0.0`                               | Bind address for the WebXR server.                   |
+| `port`               | `4443`                                  | Port for the WebXR server.                           |
+| `ee_frame`           | `gripper_frame_link`                    | End-effector frame for FK and IK.                    |
+| `root_frame`         | `base_link`                             | Reference frame for teleop deltas and visualization. |
+| `control_rate`       | `50.0`                                  | IK solve and command publish rate (Hz).              |
+| `inactivity_timeout` | `0.3`                                   | Seconds of phone stillness before IK halts.          |
+| `gripper_open_speed` | `5.0`                                   | Gripper ramping speed while A/B is held (rad/s).     |
+| `command_topic`      | `/forward_position_controller/commands` | Joint command topic.                                 |

--- a/pai_phone_teleop/README.md
+++ b/pai_phone_teleop/README.md
@@ -1,0 +1,52 @@
+# pai_phone_teleop
+
+Phone-based 6-DoF pose teleoperation for the SO-ARM101.
+
+This package wraps the upstream [`teleop`](https://github.com/SpesRobotics/teleop)
+`python3 -m teleop.ros2` WebXR bridge and supplies it with the end-effector's
+current pose via the `ee_pose_publisher` node.
+
+## Status
+
+This iteration publishes the EE current pose and runs the phone bridge.
+Driving the arm from the phone-published target is **out of scope** and
+will be added in a future iteration.
+
+## How to run
+
+1. Launch any `pai_bringup` bringup (real / mujoco / gz), e.g.:
+
+   ```bash
+   ros2 launch pai_bringup so_arm_mujoco_bringup.launch.py
+   ```
+
+2. Launch the phone teleop:
+
+   ```bash
+   ros2 launch pai_phone_teleop phone_teleop.launch.py
+   ```
+
+3. Open the URL logged to stdout (default `http://<host>:4443/`) on a
+   phone with a WebXR-capable browser (e.g. Chrome on Android). Hold the
+   phone in the WebXR "natural orientation" (screen up, camera toward you)
+   and press the **Move** button on screen to begin streaming.
+
+## Topics
+
+| Topic | Direction | Type | Notes |
+|---|---|---|---|
+| `/current_pose` | Publishes | `geometry_msgs/PoseStamped` | EE pose in `base_link` frame, computed from `/joint_states` FK. Consumed by `teleop.ros2`. |
+| `/target_frame` | Subscribes (deferred) | `geometry_msgs/PoseStamped` | Published by `teleop.ros2`. Will be consumed in a future iteration to drive the arm. |
+| `/tf` | Publishes (`teleop_target`) | `tf2_msgs/TFMessage` | `base_link -> teleop_target`, published by `teleop.ros2` for RViz visualization. |
+
+## Known limitations
+
+- `teleop.ros2` hard-codes the published `target_frame` `frame_id` to
+  `"link_base"` (likely a typo in the upstream library). The TF broadcaster
+  uses the correct `base_link`. Downstream consumers should rely on the
+  TF or remap/override the frame_id.
+- The `omit_current_pose` launch argument is declared but not yet wired
+  into the `teleop.ros2` command; we always run without the flag, which
+  is the documented correct default (use `/current_pose` as the seed).
+- Gripper mapping is not supported by upstream `teleop.ros2`. Use
+  `teleop.ros2_ik` for that, or wait for the future iteration.

--- a/pai_phone_teleop/README.md
+++ b/pai_phone_teleop/README.md
@@ -7,6 +7,9 @@ WebXR bridge together with Pinocchio forward kinematics and Pink differential
 IK. The arm tracks the phone's 6-DoF pose in real time by streaming joint
 positions to the `forward_position_controller`.
 
+> [!IMPORTANT]
+> Your phone has to support the [WebXR API](https://developer.mozilla.org/en-US/docs/Web/API/WebXR_Device_API). Unfortunately, iPhone doesn't support the WebXR API.
+
 ## How to run
 
 1. Launch any `pai_bringup` bringup (real / mujoco / gz), e.g.:

--- a/pai_phone_teleop/launch/phone_teleop.launch.py
+++ b/pai_phone_teleop/launch/phone_teleop.launch.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (C) 2026 Sebastian Castro
+# Copyright (C) 2026 Franco Cipollone
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -21,10 +21,12 @@ Starts a single ``phone_teleop_node`` that:
 1. Subscribes to ``/joint_states`` and runs forward kinematics to track the
    current end-effector pose.
 2. Embeds ``teleop.Teleop`` (WebXR WebSocket server) in a background thread,
-   keeping it seeded with the live EE pose.
-3. Publishes the phone-commanded target on ``target_frame``
-   (``geometry_msgs/PoseStamped``) and broadcasts a TF
-   ``root_frame → teleop_target`` for RViz visualization.
+   keeping it seeded with the live EE pose expressed in ``root_frame``.
+3. On every phone move, solves differential IK toward the commanded target and
+   publishes joint positions to the ``forward_position_controller``.
+4. Publishes the raw phone target as a ``geometry_msgs/PoseStamped`` on
+   ``teleop_target`` and broadcasts ``root_frame → teleop_target`` TF for
+   RViz visualization.
 
 The user is expected to have launched a ``pai_bringup`` bringup (real,
 mujoco, or gz) in a separate terminal.
@@ -56,17 +58,33 @@ def generate_launch_description():
         ),
         DeclareLaunchArgument(
             "root_frame",
-            default_value="world",
+            default_value="base_link",
             description=(
-                "Reference frame for the published target_frame PoseStamped "
-                "and TF broadcast.  Must match Pinocchio's universe frame "
-                "(i.e. the URDF root link, 'world' for the SO-ARM101)."
+                "Reference frame for the teleop target PoseStamped and TF broadcast.  "
+                "The IK solver always operates in Pinocchio's universe frame; this node "
+                "converts to/from root_frame so phone deltas feel natural relative to "
+                "the arm base.  Defaults to 'base_link' (arm's natural base frame)."
             ),
         ),
         DeclareLaunchArgument(
             "node_name",
             default_value="phone_teleop",
             description="Name of the phone_teleop_node.",
+        ),
+        DeclareLaunchArgument(
+            "command_topic",
+            default_value="/forward_position_controller/commands",
+            description="Float64MultiArray topic consumed by the forward_position_controller.",
+        ),
+        DeclareLaunchArgument(
+            "control_rate",
+            default_value="50.0",
+            description="IK control loop rate in Hz.",
+        ),
+        DeclareLaunchArgument(
+            "inactivity_timeout",
+            default_value="0.3",
+            description="Seconds after the phone stops moving before commands halt.",
         ),
     ]
 
@@ -81,6 +99,9 @@ def generate_launch_description():
                 "port": LaunchConfiguration("port"),
                 "ee_frame": LaunchConfiguration("ee_frame"),
                 "root_frame": LaunchConfiguration("root_frame"),
+                "command_topic": LaunchConfiguration("command_topic"),
+                "control_rate": LaunchConfiguration("control_rate"),
+                "inactivity_timeout": LaunchConfiguration("inactivity_timeout"),
             }
         ],
     )

--- a/pai_phone_teleop/launch/phone_teleop.launch.py
+++ b/pai_phone_teleop/launch/phone_teleop.launch.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2026 Sebastian Castro
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Phone teleop launch: integrated PhoneTeleopNode (FK + teleop.Teleop WebXR bridge).
+
+Starts a single ``phone_teleop_node`` that:
+
+1. Subscribes to ``/joint_states`` and runs forward kinematics to track the
+   current end-effector pose.
+2. Embeds ``teleop.Teleop`` (WebXR WebSocket server) in a background thread,
+   keeping it seeded with the live EE pose.
+3. Publishes the phone-commanded target on ``target_frame``
+   (``geometry_msgs/PoseStamped``) and broadcasts a TF
+   ``root_frame → teleop_target`` for RViz visualization.
+
+The user is expected to have launched a ``pai_bringup`` bringup (real,
+mujoco, or gz) in a separate terminal.
+"""
+
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument
+from launch.substitutions import LaunchConfiguration
+from launch_ros.actions import Node
+
+
+def generate_launch_description():
+    """Generate the phone teleop launch description."""
+    declared_arguments = [
+        DeclareLaunchArgument(
+            "host",
+            default_value="0.0.0.0",
+            description="Bind address for the teleop.Teleop WebXR server.",
+        ),
+        DeclareLaunchArgument(
+            "port",
+            default_value="4443",
+            description="Port for the teleop.Teleop WebXR server.",
+        ),
+        DeclareLaunchArgument(
+            "ee_frame",
+            default_value="gripper_frame_link",
+            description="End-effector frame whose pose is tracked and published.",
+        ),
+        DeclareLaunchArgument(
+            "root_frame",
+            default_value="world",
+            description=(
+                "Reference frame for the published target_frame PoseStamped "
+                "and TF broadcast.  Must match Pinocchio's universe frame "
+                "(i.e. the URDF root link, 'world' for the SO-ARM101)."
+            ),
+        ),
+        DeclareLaunchArgument(
+            "node_name",
+            default_value="phone_teleop",
+            description="Name of the phone_teleop_node.",
+        ),
+    ]
+
+    phone_teleop_node = Node(
+        package="pai_phone_teleop",
+        executable="phone_teleop_node",
+        name=LaunchConfiguration("node_name"),
+        output="both",
+        parameters=[
+            {
+                "host": LaunchConfiguration("host"),
+                "port": LaunchConfiguration("port"),
+                "ee_frame": LaunchConfiguration("ee_frame"),
+                "root_frame": LaunchConfiguration("root_frame"),
+            }
+        ],
+    )
+
+    return LaunchDescription(
+        [
+            *declared_arguments,
+            phone_teleop_node,
+        ]
+    )

--- a/pai_phone_teleop/package.xml
+++ b/pai_phone_teleop/package.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>pai_phone_teleop</name>
+  <version>0.1.0</version>
+  <description>
+    Phone-based 6-DoF pose teleoperation for the SO-ARM101. Wraps the
+    upstream teleop.ros2 WebXR bridge and supplies it with the end-effector's
+    current pose, computed via Pinocchio forward kinematics on /joint_states.
+    Driving the arm's joints from the published target pose is out of scope
+    for this iteration.
+  </description>
+  <maintainer email="sebas.a.castro@gmail.com">Sebastian Castro</maintainer>
+  <license>Apache License 2.0</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>ament_cmake_python</buildtool_depend>
+
+  <exec_depend>geometry_msgs</exec_depend>
+  <exec_depend>launch</exec_depend>
+  <exec_depend>launch_ros</exec_depend>
+  <exec_depend>pai_rviz_teleop</exec_depend>
+  <exec_depend>rclpy</exec_depend>
+  <exec_depend>sensor_msgs</exec_depend>
+  <exec_depend>std_msgs</exec_depend>
+  <exec_depend>teleop</exec_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/pai_phone_teleop/package.xml
+++ b/pai_phone_teleop/package.xml
@@ -4,13 +4,13 @@
   <name>pai_phone_teleop</name>
   <version>0.1.0</version>
   <description>
-    Phone-based 6-DoF pose teleoperation for the SO-ARM101. Wraps the
-    upstream teleop.ros2 WebXR bridge and supplies it with the end-effector's
-    current pose, computed via Pinocchio forward kinematics on /joint_states.
-    Driving the arm's joints from the published target pose is out of scope
-    for this iteration.
+    Phone-based 6-DoF pose teleoperation for the SO-ARM101. Embeds the
+    upstream teleop WebXR bridge together with Pinocchio forward kinematics
+    and Pink differential IK in a single ROS 2 node. The arm tracks the
+    phone's 6-DoF pose in real time by streaming joint commands to the
+    forward_position_controller.
   </description>
-  <maintainer email="sebas.a.castro@gmail.com">Sebastian Castro</maintainer>
+  <maintainer email="franco.cipollone@ekumenlabs.com">Franco Cipollone</maintainer>
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>

--- a/pai_phone_teleop/pai_phone_teleop/__init__.py
+++ b/pai_phone_teleop/pai_phone_teleop/__init__.py
@@ -5,3 +5,5 @@
 # You may obtain a copy of the License at
 #
 #     http://www.apache.org/licenses/LICENSE-2.0
+
+"""Phone teleop package initializer."""

--- a/pai_phone_teleop/pai_phone_teleop/__init__.py
+++ b/pai_phone_teleop/pai_phone_teleop/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2026 Sebastian Castro
+# Copyright (C) 2026 Franco Cipollone
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pai_phone_teleop/pai_phone_teleop/__init__.py
+++ b/pai_phone_teleop/pai_phone_teleop/__init__.py
@@ -1,0 +1,7 @@
+# Copyright (C) 2026 Sebastian Castro
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0

--- a/pai_phone_teleop/pai_phone_teleop/phone_teleop_node.py
+++ b/pai_phone_teleop/pai_phone_teleop/phone_teleop_node.py
@@ -1,0 +1,296 @@
+# Copyright (C) 2026 Franco Cipollone
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Integrated phone-teleop node: FK + teleop.Teleop WebXR bridge.
+
+Replaces the two-process design (``ee_pose_publisher`` node +
+``python3 -m teleop.ros2`` subprocess) with a single rclpy node that embeds
+the ``teleop.Teleop`` WebXR server in a background thread.
+
+Architecture
+------------
+* Main thread — ``executor.spin()`` handles all ROS callbacks.
+* Daemon thread — ``teleop.Teleop.run()`` (blocking uvicorn server).
+* ``_joint_state_cb`` (executor thread) — runs FK, calls
+  ``teleop.set_pose(T)`` so the bridge always has the current EE pose as its
+  internal reference.  ``Teleop.set_pose`` is a simple attribute assignment,
+  safe to call from any thread.
+* ``_teleop_cb`` (uvicorn/asyncio thread) — called by the bridge on every
+  WebSocket frame.  When the phone is moving it publishes a
+  ``geometry_msgs/PoseStamped`` on ``teleop_target`` and a TF transform
+  ``root_frame → teleop_target``.  rclpy publisher ``publish()`` and
+  ``TransformBroadcaster.sendTransform()`` are thread-safe.
+
+Topics
+------
+Subscribes:
+  ``/joint_states``        sensor_msgs/JointState
+  ``/robot_description``   std_msgs/String  (transient-local / latched)
+
+Publishes:
+  ``teleop_target``         geometry_msgs/PoseStamped  (EE target in root_frame)
+  ``/tf``                  via TransformBroadcaster (root_frame → teleop_target)
+"""
+
+from __future__ import annotations
+
+import threading
+
+import numpy as np
+import pinocchio as pin
+import rclpy
+import transforms3d as t3d
+from geometry_msgs.msg import PoseStamped, TransformStamped
+from rclpy.node import Node
+from rclpy.qos import QoSDurabilityPolicy, QoSHistoryPolicy, QoSProfile, QoSReliabilityPolicy
+from sensor_msgs.msg import JointState
+from std_msgs.msg import String
+from teleop import Teleop
+from tf2_ros import TransformBroadcaster
+
+from pai_rviz_teleop.ik_solver import DifferentialIKSolver
+
+# Default arm joints for the SO-ARM101, in order.  The gripper joint is
+# intentionally excluded — it does not move the tool frame.
+DEFAULT_ARM_JOINTS = [
+    "shoulder_pan_joint",
+    "shoulder_lift_joint",
+    "elbow_flex_joint",
+    "wrist_flex_joint",
+    "wrist_roll_joint",
+]
+
+
+def transient_local_qos(depth: int = 1) -> QoSProfile:
+    """QoS matching latched publishers such as ``/robot_description``."""
+    return QoSProfile(
+        history=QoSHistoryPolicy.KEEP_LAST,
+        depth=depth,
+        reliability=QoSReliabilityPolicy.RELIABLE,
+        durability=QoSDurabilityPolicy.TRANSIENT_LOCAL,
+    )
+
+
+def _se3_to_mat(se3: pin.SE3) -> np.ndarray:
+    """Convert a Pinocchio SE3 to a 4×4 homogeneous matrix."""
+    T = np.eye(4)
+    T[:3, :3] = se3.rotation
+    T[:3, 3] = se3.translation
+    return T
+
+
+class PhoneTeleopNode(Node):
+    """Single node that runs FK and the teleop.Teleop WebXR bridge together."""
+
+    def __init__(self) -> None:
+        """Declare parameters, build solver, start teleop server thread."""
+        super().__init__("phone_teleop")
+
+        self.declare_parameter("joint_states_topic", "/joint_states")
+        self.declare_parameter("robot_description_topic", "/robot_description")
+        self.declare_parameter("teleop_target_topic", "teleop_target")
+        self.declare_parameter("ee_frame", "gripper_frame_link")
+        # root_frame must match Pinocchio's universe frame, which for the
+        # SO-ARM101 URDF is "world" (the URDF root link).  Changing this only
+        # relabels the published frame_id; the FK coordinates do not change.
+        self.declare_parameter("root_frame", "world")
+        self.declare_parameter("arm_joints", DEFAULT_ARM_JOINTS)
+        # teleop.Teleop server settings
+        self.declare_parameter("host", "0.0.0.0")
+        self.declare_parameter("port", 4443)
+        self.declare_parameter(
+            "natural_orientation",
+            [0.0, -45.0, 0.0],
+        )
+        self.declare_parameter("natural_position", [0.0, 0.0, 0.0])
+        # IK solver weights (forwarded to DifferentialIKSolver; unused in FK
+        # path but kept here so a future IK consumer can share the same node).
+        self.declare_parameter("position_cost", 0.5)
+        self.declare_parameter("orientation_cost", 0.1)
+        self.declare_parameter("posture_cost", 1e-3)
+        self.declare_parameter("lm_damping", 1e-2)
+        self.declare_parameter("max_joint_velocity", 2.0)
+        self.declare_parameter("max_joint_acceleration", 10.0)
+        self.declare_parameter("qp_solver", "quadprog")
+
+        self._joint_states_topic = self.get_parameter("joint_states_topic").value
+        self._robot_description_topic = self.get_parameter("robot_description_topic").value
+        self._teleop_target_topic = self.get_parameter("teleop_target_topic").value
+        self._ee_frame = self.get_parameter("ee_frame").value
+        self._root_frame = self.get_parameter("root_frame").value
+        arm_joints = list(self.get_parameter("arm_joints").value)
+
+        # Build the FK/IK solver.
+        urdf_xml = self._wait_for_robot_description()
+        self._solver = DifferentialIKSolver(
+            urdf_xml,
+            arm_joints,
+            self._ee_frame,
+            position_cost=float(self.get_parameter("position_cost").value),
+            orientation_cost=float(self.get_parameter("orientation_cost").value),
+            posture_cost=float(self.get_parameter("posture_cost").value),
+            lm_damping=float(self.get_parameter("lm_damping").value),
+            max_joint_velocity=float(self.get_parameter("max_joint_velocity").value),
+            max_joint_acceleration=float(self.get_parameter("max_joint_acceleration").value),
+            qp_solver=self.get_parameter("qp_solver").value,
+        )
+
+        # teleop.Teleop expects the natural_orientation in radians.
+        natural_orientation_deg = list(self.get_parameter("natural_orientation").value)
+        natural_orientation_rad = [np.deg2rad(d) for d in natural_orientation_deg]
+        natural_position = list(self.get_parameter("natural_position").value)
+
+        self._teleop = Teleop(
+            host=self.get_parameter("host").value,
+            port=int(self.get_parameter("port").value),
+            natural_phone_orientation_euler=natural_orientation_rad,
+            natural_phone_position=natural_position,
+        )
+        self._teleop.subscribe(self._teleop_cb)
+
+        # ROS I/O
+        self._target_pub = self.create_publisher(PoseStamped, self._teleop_target_topic, 1)
+        self._tf_broadcaster = TransformBroadcaster(self)
+
+        self._warned_missing: set[str] = set()
+
+        self._joint_state_sub = self.create_subscription(
+            JointState, self._joint_states_topic, self._joint_state_cb, 10
+        )
+
+        # Start the blocking uvicorn server in a daemon thread so it dies
+        # automatically when the process exits.
+        self._teleop_thread = threading.Thread(
+            target=self._teleop.run, daemon=True, name="teleop_server"
+        )
+        self._teleop_thread.start()
+        self.get_logger().info(
+            f"Phone teleop node ready. "
+            f"ee_frame='{self._ee_frame}', root_frame='{self._root_frame}', "
+            f"teleop_target_topic='{self._teleop_target_topic}'."
+        )
+
+    # ------------------------------------------------------------------
+    # URDF wait (identical pattern to ee_pose_publisher)
+    # ------------------------------------------------------------------
+    def _wait_for_robot_description(self) -> str:
+        """Block until the latched URDF is received."""
+        topic = self._robot_description_topic
+        result: dict[str, str] = {}
+        event = threading.Event()
+
+        def _cb(msg: String) -> None:
+            result["urdf"] = msg.data
+            event.set()
+
+        sub = self.create_subscription(String, topic, _cb, transient_local_qos())
+        self.get_logger().info(f"Waiting for {topic} ...")
+        while rclpy.ok() and not event.is_set():
+            rclpy.spin_once(self, timeout_sec=0.1)
+        self.destroy_subscription(sub)
+        if "urdf" not in result:
+            raise RuntimeError(f"Did not receive {topic}")
+        self.get_logger().info(f"Received robot description from {topic}.")
+        return result["urdf"]
+
+    # ------------------------------------------------------------------
+    # Joint state callback (executor thread)
+    # ------------------------------------------------------------------
+    def _joint_state_cb(self, msg: JointState) -> None:
+        """Run FK and update teleop's internal reference pose."""
+        positions = dict(zip(msg.name, msg.position, strict=False))
+
+        q = self._solver.configuration_from_dict(positions)
+        if q is None:
+            for joint in self._solver.joint_names:
+                if joint not in positions and joint not in self._warned_missing:
+                    self.get_logger().warn(
+                        f"Arm joint '{joint}' missing from {self._joint_states_topic}; "
+                        "skipping this message. (Subsequent misses will not be logged.)"
+                    )
+                    self._warned_missing.add(joint)
+            return
+
+        self._solver.reset(q)
+        pose_se3 = self._solver.forward_kinematics()
+        # Keep teleop seeded with the current EE pose so the bridge can
+        # compute phone-relative deltas from the actual arm position.
+        self._teleop.set_pose(_se3_to_mat(pose_se3))
+
+    # ------------------------------------------------------------------
+    # Teleop callback (uvicorn/asyncio thread)
+    # ------------------------------------------------------------------
+    def _teleop_cb(self, pose: np.ndarray, params: dict) -> None:
+        """Publish the phone-commanded EE target pose.
+
+        Called by ``teleop.Teleop`` on every WebSocket frame.  ``pose`` is a
+        4×4 homogeneous matrix in ``root_frame`` coordinates.
+
+        When ``params["move"]`` is ``False`` the phone is at rest; teleop
+        emits the current (unchanged) reference pose.  We skip publishing in
+        that state — the arm should hold its position until a new target
+        arrives.
+        """
+        if not params.get("move", False):
+            return
+
+        stamp = self.get_clock().now().to_msg()
+
+        # --- PoseStamped on teleop_target topic ---
+        msg = PoseStamped()
+        msg.header.stamp = stamp
+        msg.header.frame_id = self._root_frame
+        msg.pose.position.x = float(pose[0, 3])
+        msg.pose.position.y = float(pose[1, 3])
+        msg.pose.position.z = float(pose[2, 3])
+        quat = t3d.quaternions.mat2quat(pose[:3, :3])  # [w, x, y, z]
+        msg.pose.orientation.w = float(quat[0])
+        msg.pose.orientation.x = float(quat[1])
+        msg.pose.orientation.y = float(quat[2])
+        msg.pose.orientation.z = float(quat[3])
+        self._target_pub.publish(msg)
+
+        # --- TF: root_frame → teleop_target (for RViz visualization) ---
+        tf_msg = TransformStamped()
+        tf_msg.header.stamp = stamp
+        tf_msg.header.frame_id = self._root_frame
+        tf_msg.child_frame_id = "teleop_target"
+        tf_msg.transform.translation.x = float(pose[0, 3])
+        tf_msg.transform.translation.y = float(pose[1, 3])
+        tf_msg.transform.translation.z = float(pose[2, 3])
+        tf_msg.transform.rotation.w = float(quat[0])
+        tf_msg.transform.rotation.x = float(quat[1])
+        tf_msg.transform.rotation.y = float(quat[2])
+        tf_msg.transform.rotation.z = float(quat[3])
+        self._tf_broadcaster.sendTransform(tf_msg)
+
+
+def main(args: list[str] | None = None) -> None:
+    """Entry point for the phone teleop node."""
+    rclpy.init(args=args)
+    node = PhoneTeleopNode()
+    executor = rclpy.executors.MultiThreadedExecutor()
+    executor.add_node(node)
+    try:
+        executor.spin()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        node.destroy_node()
+        if rclpy.ok():
+            rclpy.shutdown()
+
+
+if __name__ == "__main__":
+    main()

--- a/pai_phone_teleop/pai_phone_teleop/phone_teleop_node.py
+++ b/pai_phone_teleop/pai_phone_teleop/phone_teleop_node.py
@@ -138,6 +138,9 @@ class PhoneTeleopNode(Node):
         self.declare_parameter("gripper_joint", "gripper_joint")
         self.declare_parameter("inactivity_timeout", 0.3)
         self.declare_parameter("target_lowpass_alpha", 0.5)
+        # Speed at which the gripper opens (A) or closes (B) while the
+        # corresponding button is held, in rad/s.
+        self.declare_parameter("gripper_open_speed", 5.0)
 
         self._joint_states_topic = self.get_parameter("joint_states_topic").value
         self._robot_description_topic = self.get_parameter("robot_description_topic").value
@@ -178,6 +181,19 @@ class PhoneTeleopNode(Node):
         if self._has_gripper:
             self._command_joints.append(self._gripper_joint)
 
+        # Gripper joint position limits (from URDF via the full Pinocchio model)
+        # and open/close speed driven by reserved buttons A and B.
+        self._gripper_open_speed = float(self.get_parameter("gripper_open_speed").value)
+        if self._has_gripper:
+            _full = self._solver.full_model
+            _jid = _full.getJointId(self._gripper_joint)
+            _idx = _full.joints[_jid].idx_q
+            self._gripper_min = float(_full.lowerPositionLimit[_idx])
+            self._gripper_max = float(_full.upperPositionLimit[_idx])
+        else:
+            self._gripper_min = 0.0
+            self._gripper_max = 0.0
+
         # Precompute the fixed SE3 from Pinocchio universe ("world" URDF root)
         # to root_frame.  For a fixed-base arm this is constant — base_link is
         # connected to world via a fixed joint so its placement never changes.
@@ -208,10 +224,16 @@ class PhoneTeleopNode(Node):
         self._measured_q: np.ndarray | None = None
         self._gripper_position: float = 0.0
         self._ik_initialized = False
+        self._last_q_cmd: np.ndarray | None = None  # last arm configuration sent
         self._target_se3: pin.SE3 | None = None
         self._target_filtered_se3: pin.SE3 | None = None
         self._last_move_time: rclpy.time.Time | None = None
         self._warned_missing: set[str] = set()
+        # Button A → open gripper slowly; button B → close slowly (held = ramping).
+        # Gripper button (engaged) → lock position at 0 (apply pressure).
+        self._button_a_held: bool = False
+        self._button_b_held: bool = False
+        self._gripper_engaged: bool = False
 
         self._joint_state_sub = self.create_subscription(
             JointState, self._joint_states_topic, self._joint_state_cb, 10
@@ -305,7 +327,18 @@ class PhoneTeleopNode(Node):
         control loop and the ``teleop_target`` PoseStamped + TF are published
         for visualization.  When ``move`` is ``False`` the phone is at rest;
         we skip publishing so the arm holds its last commanded position.
+
+        Button states (``reservedButtonA`` / ``reservedButtonB``) are captured
+        regardless of ``move`` so the gripper can be operated while the arm is
+        stationary.
         """
+        # Capture button/gripper states before the move guard so the gripper
+        # can be operated independently of arm motion.
+        with self._lock:
+            self._button_a_held = bool(params.get("reservedButtonA", False))
+            self._button_b_held = bool(params.get("reservedButtonB", False))
+            self._gripper_engaged = params.get("gripper", "open") == "close"
+
         if not params.get("move", False):
             return
 
@@ -408,33 +441,52 @@ class PhoneTeleopNode(Node):
             T_root_ee = self._T_world_root.inverse() * T_world_ee
             self._teleop.set_pose(_se3_to_mat(T_root_ee))
 
-            # Inactivity gate: stop solving when the phone has been at rest.
+            # Gripper control before the inactivity gate so it works
+            # independently of arm motion.
+            # Engaged (gripper button held): lock at 0 to apply pressure.
+            # Disengaged: A ramps open, B ramps closed.
+            if self._has_gripper:
+                if self._gripper_engaged:
+                    self._gripper_position = self._gripper_min
+                elif self._button_a_held:
+                    self._gripper_position = min(
+                        self._gripper_position + self._gripper_open_speed * dt,
+                        self._gripper_max,
+                    )
+                elif self._button_b_held:
+                    self._gripper_position = max(
+                        self._gripper_position - self._gripper_open_speed * dt,
+                        self._gripper_min,
+                    )
+
+            # Inactivity gate: stop IK when the phone has been at rest.
             arm_active = self._last_move_time is not None and (
                 (now - self._last_move_time).nanoseconds * 1e-9 < self._inactivity_timeout
             )
 
-            if not arm_active or self._target_se3 is None:
-                self._solver.set_zero_velocity()
-                return
-
-            # SE3 low-pass filter: geodesic step from the filtered target
-            # toward the latest raw target.
-            if self._target_filtered_se3 is None:
-                self._target_filtered_se3 = self._target_se3
+            if arm_active and self._target_se3 is not None:
+                # SE3 low-pass filter: geodesic step from the filtered target
+                # toward the latest raw target.
+                if self._target_filtered_se3 is None:
+                    self._target_filtered_se3 = self._target_se3
+                else:
+                    delta = pin.log6(self._target_filtered_se3.actInv(self._target_se3)).vector
+                    self._target_filtered_se3 = self._target_filtered_se3 * pin.exp6(
+                        self._lowpass_alpha * delta
+                    )
+                try:
+                    # Convert the filtered target from root_frame back to world
+                    # (Pinocchio universe) frame before passing it to the IK solver.
+                    T_world_target = self._T_world_root * self._target_filtered_se3
+                    q_cmd = self._solver.solve(T_world_target, dt)
+                    self._last_q_cmd = q_cmd
+                except Exception as exc:
+                    self.get_logger().warn(f"IK solve failed: {exc}")
             else:
-                delta = pin.log6(self._target_filtered_se3.actInv(self._target_se3)).vector
-                self._target_filtered_se3 = self._target_filtered_se3 * pin.exp6(
-                    self._lowpass_alpha * delta
-                )
-
-            try:
-                # Convert the filtered target from root_frame back to world
-                # (Pinocchio universe) frame before passing it to the IK solver.
-                T_world_target = self._T_world_root * self._target_filtered_se3
-                q_cmd = self._solver.solve(T_world_target, dt)
-            except Exception as exc:
-                self.get_logger().warn(f"IK solve failed: {exc}")
-                return
+                self._solver.set_zero_velocity()
+                # Re-use the last commanded arm configuration so a gripper-only
+                # update can still be published while the arm is at rest.
+                q_cmd = self._last_q_cmd
 
             gripper = self._gripper_position if self._has_gripper else None
 

--- a/pai_phone_teleop/pai_phone_teleop/phone_teleop_node.py
+++ b/pai_phone_teleop/pai_phone_teleop/phone_teleop_node.py
@@ -12,25 +12,32 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Integrated phone-teleop node: FK + teleop.Teleop WebXR bridge.
-
-Replaces the two-process design (``ee_pose_publisher`` node +
-``python3 -m teleop.ros2`` subprocess) with a single rclpy node that embeds
-the ``teleop.Teleop`` WebXR server in a background thread.
+"""Integrated phone-teleop node: FK + teleop.Teleop WebXR bridge + differential IK.
 
 Architecture
 ------------
 * Main thread — ``executor.spin()`` handles all ROS callbacks.
-* Daemon thread — ``teleop.Teleop.run()`` (blocking uvicorn server).
-* ``_joint_state_cb`` (executor thread) — runs FK, calls
-  ``teleop.set_pose(T)`` so the bridge always has the current EE pose as its
-  internal reference.  ``Teleop.set_pose`` is a simple attribute assignment,
-  safe to call from any thread.
-* ``_teleop_cb`` (uvicorn/asyncio thread) — called by the bridge on every
-  WebSocket frame.  When the phone is moving it publishes a
-  ``geometry_msgs/PoseStamped`` on ``teleop_target`` and a TF transform
-  ``root_frame → teleop_target``.  rclpy publisher ``publish()`` and
-  ``TransformBroadcaster.sendTransform()`` are thread-safe.
+* Daemon thread — ``teleop.Teleop.run()`` (blocking uvicorn/WebSocket server).
+* ``_joint_state_cb`` (executor thread) — caches the latest measured joint
+  positions and gripper angle under ``_lock``.  Does not touch the IK solver.
+* ``_teleop_cb`` (uvicorn/asyncio thread) — called on every WebSocket frame.
+  When the phone is moving, stores the commanded target (a 4×4 matrix in
+  ``root_frame``) for the control loop and publishes visualization topics.
+* ``_control_loop`` (executor timer, ``MutuallyExclusiveCallbackGroup``) —
+  runs at ``control_rate`` Hz.  Seeds ``teleop.set_pose()`` with the current
+  commanded EE pose expressed in ``root_frame``, then solves differential IK
+  toward the latest phone target (converted back to Pinocchio's universe frame)
+  and publishes joint commands to the ``forward_position_controller``.
+
+Frame handling
+--------------
+Pinocchio FK always returns poses in its universe frame (= the URDF ``world``
+root link).  The arm's ``base_link`` is mounted with a non-trivial offset and
+yaw=π relative to ``world``, so without conversion the phone's translational
+deltas would feel inverted.  ``_T_world_root`` (precomputed at init) is the
+fixed SE3 from the universe frame to ``root_frame`` (default ``base_link``).
+The control loop converts EE pose → root_frame for teleop seeding and converts
+the phone target → universe frame before the IK solve.
 
 Topics
 ------
@@ -39,8 +46,9 @@ Subscribes:
   ``/robot_description``   std_msgs/String  (transient-local / latched)
 
 Publishes:
-  ``teleop_target``         geometry_msgs/PoseStamped  (EE target in root_frame)
-  ``/tf``                  via TransformBroadcaster (root_frame → teleop_target)
+  ``teleop_target``        geometry_msgs/PoseStamped (phone target in root_frame)
+  ``/tf``                  TransformBroadcaster (root_frame → teleop_target)
+  ``<command_topic>``      std_msgs/Float64MultiArray → forward_position_controller
 """
 
 from __future__ import annotations
@@ -52,10 +60,11 @@ import pinocchio as pin
 import rclpy
 import transforms3d as t3d
 from geometry_msgs.msg import PoseStamped, TransformStamped
+from rclpy.callback_groups import MutuallyExclusiveCallbackGroup
 from rclpy.node import Node
 from rclpy.qos import QoSDurabilityPolicy, QoSHistoryPolicy, QoSProfile, QoSReliabilityPolicy
 from sensor_msgs.msg import JointState
-from std_msgs.msg import String
+from std_msgs.msg import Float64MultiArray, String
 from teleop import Teleop
 from tf2_ros import TransformBroadcaster
 
@@ -101,21 +110,21 @@ class PhoneTeleopNode(Node):
         self.declare_parameter("robot_description_topic", "/robot_description")
         self.declare_parameter("teleop_target_topic", "teleop_target")
         self.declare_parameter("ee_frame", "gripper_frame_link")
-        # root_frame must match Pinocchio's universe frame, which for the
-        # SO-ARM101 URDF is "world" (the URDF root link).  Changing this only
-        # relabels the published frame_id; the FK coordinates do not change.
-        self.declare_parameter("root_frame", "world")
+        # root_frame sets the reference frame for the teleop bridge and the
+        # published PoseStamped/TF.  FK is always computed in Pinocchio's
+        # universe frame; the node converts to/from root_frame so that phone
+        # translational deltas feel natural relative to the arm's base.
+        self.declare_parameter("root_frame", "base_link")
         self.declare_parameter("arm_joints", DEFAULT_ARM_JOINTS)
         # teleop.Teleop server settings
         self.declare_parameter("host", "0.0.0.0")
         self.declare_parameter("port", 4443)
         self.declare_parameter(
             "natural_orientation",
-            [0.0, -45.0, 0.0],
+            [0.0, 0.0, 0.0],
         )
         self.declare_parameter("natural_position", [0.0, 0.0, 0.0])
-        # IK solver weights (forwarded to DifferentialIKSolver; unused in FK
-        # path but kept here so a future IK consumer can share the same node).
+        # IK solver weights forwarded directly to DifferentialIKSolver.
         self.declare_parameter("position_cost", 0.5)
         self.declare_parameter("orientation_cost", 0.1)
         self.declare_parameter("posture_cost", 1e-3)
@@ -123,6 +132,12 @@ class PhoneTeleopNode(Node):
         self.declare_parameter("max_joint_velocity", 2.0)
         self.declare_parameter("max_joint_acceleration", 10.0)
         self.declare_parameter("qp_solver", "quadprog")
+        # IK control loop settings.
+        self.declare_parameter("control_rate", 50.0)
+        self.declare_parameter("command_topic", "/forward_position_controller/commands")
+        self.declare_parameter("gripper_joint", "gripper_joint")
+        self.declare_parameter("inactivity_timeout", 0.3)
+        self.declare_parameter("target_lowpass_alpha", 0.5)
 
         self._joint_states_topic = self.get_parameter("joint_states_topic").value
         self._robot_description_topic = self.get_parameter("robot_description_topic").value
@@ -146,6 +161,28 @@ class PhoneTeleopNode(Node):
             qp_solver=self.get_parameter("qp_solver").value,
         )
 
+        # Detect gripper and build the ordered command joint list.
+        gripper_joint_param = self.get_parameter("gripper_joint").value
+        self._gripper_joint: str | None = gripper_joint_param if gripper_joint_param else None
+        self._has_gripper = (
+            self._gripper_joint is not None
+            and self._solver.full_model.existJointName(self._gripper_joint)
+        )
+        if self._gripper_joint and not self._has_gripper:
+            self.get_logger().warn(
+                f"gripper_joint '{self._gripper_joint}' not found in URDF; "
+                "gripper will be omitted from commands."
+            )
+        # Arm joints first, then gripper (matches forward_position_controller order).
+        self._command_joints = list(self._solver.joint_names)
+        if self._has_gripper:
+            self._command_joints.append(self._gripper_joint)
+
+        # Precompute the fixed SE3 from Pinocchio universe ("world" URDF root)
+        # to root_frame.  For a fixed-base arm this is constant — base_link is
+        # connected to world via a fixed joint so its placement never changes.
+        self._T_world_root: pin.SE3 = self._precompute_T_world_root()
+
         # teleop.Teleop expects the natural_orientation in radians.
         natural_orientation_deg = list(self.get_parameter("natural_orientation").value)
         natural_orientation_rad = [np.deg2rad(d) for d in natural_orientation_deg]
@@ -162,11 +199,36 @@ class PhoneTeleopNode(Node):
         # ROS I/O
         self._target_pub = self.create_publisher(PoseStamped, self._teleop_target_topic, 1)
         self._tf_broadcaster = TransformBroadcaster(self)
+        command_topic = self.get_parameter("command_topic").value
+        self._command_pub = self.create_publisher(Float64MultiArray, command_topic, 10)
 
+        # Shared mutable state accessed by joint-state CB, teleop CB, and control loop.
+        # All writes and reads must be under _lock.
+        self._lock = threading.Lock()
+        self._measured_q: np.ndarray | None = None
+        self._gripper_position: float = 0.0
+        self._ik_initialized = False
+        self._target_se3: pin.SE3 | None = None
+        self._target_filtered_se3: pin.SE3 | None = None
+        self._last_move_time: rclpy.time.Time | None = None
         self._warned_missing: set[str] = set()
 
         self._joint_state_sub = self.create_subscription(
             JointState, self._joint_states_topic, self._joint_state_cb, 10
+        )
+
+        # Fixed-rate IK solve and command publishing, isolated on its own
+        # callback group so it is not starved by subscription callbacks.
+        self._control_rate = float(self.get_parameter("control_rate").value)
+        self._inactivity_timeout = float(self.get_parameter("inactivity_timeout").value)
+        self._lowpass_alpha = float(
+            np.clip(self.get_parameter("target_lowpass_alpha").value, 1e-3, 1.0)
+        )
+        self._control_group = MutuallyExclusiveCallbackGroup()
+        self._control_timer = self.create_timer(
+            1.0 / self._control_rate,
+            self._control_loop,
+            callback_group=self._control_group,
         )
 
         # Start the blocking uvicorn server in a daemon thread so it dies
@@ -178,7 +240,7 @@ class PhoneTeleopNode(Node):
         self.get_logger().info(
             f"Phone teleop node ready. "
             f"ee_frame='{self._ee_frame}', root_frame='{self._root_frame}', "
-            f"teleop_target_topic='{self._teleop_target_topic}'."
+            f"command_topic='{command_topic}', control_rate={self._control_rate:.0f} Hz."
         )
 
     # ------------------------------------------------------------------
@@ -208,42 +270,50 @@ class PhoneTeleopNode(Node):
     # Joint state callback (executor thread)
     # ------------------------------------------------------------------
     def _joint_state_cb(self, msg: JointState) -> None:
-        """Run FK and update teleop's internal reference pose."""
+        """Cache the latest measured joint positions and gripper angle.
+
+        The solver is NOT reset here — the IK control loop seeds it once at
+        initialization and integrates forward thereafter so the
+        AccelerationLimit can smooth velocity transitions between ticks.
+        """
         positions = dict(zip(msg.name, msg.position, strict=False))
-
-        q = self._solver.configuration_from_dict(positions)
-        if q is None:
-            for joint in self._solver.joint_names:
-                if joint not in positions and joint not in self._warned_missing:
-                    self.get_logger().warn(
-                        f"Arm joint '{joint}' missing from {self._joint_states_topic}; "
-                        "skipping this message. (Subsequent misses will not be logged.)"
-                    )
-                    self._warned_missing.add(joint)
-            return
-
-        self._solver.reset(q)
-        pose_se3 = self._solver.forward_kinematics()
-        # Keep teleop seeded with the current EE pose so the bridge can
-        # compute phone-relative deltas from the actual arm position.
-        self._teleop.set_pose(_se3_to_mat(pose_se3))
+        with self._lock:
+            q = self._solver.configuration_from_dict(positions)
+            if q is None:
+                for joint in self._solver.joint_names:
+                    if joint not in positions and joint not in self._warned_missing:
+                        self.get_logger().warn(
+                            f"Arm joint '{joint}' missing from {self._joint_states_topic}; "
+                            "arm joints not available yet. (Subsequent misses will not be logged.)"
+                        )
+                        self._warned_missing.add(joint)
+                return
+            self._measured_q = q
+            if self._has_gripper and self._gripper_joint in positions:
+                self._gripper_position = positions[self._gripper_joint]
 
     # ------------------------------------------------------------------
     # Teleop callback (uvicorn/asyncio thread)
     # ------------------------------------------------------------------
     def _teleop_cb(self, pose: np.ndarray, params: dict) -> None:
-        """Publish the phone-commanded EE target pose.
+        """Store the phone-commanded target and publish visualization topics.
 
         Called by ``teleop.Teleop`` on every WebSocket frame.  ``pose`` is a
         4×4 homogeneous matrix in ``root_frame`` coordinates.
 
-        When ``params["move"]`` is ``False`` the phone is at rest; teleop
-        emits the current (unchanged) reference pose.  We skip publishing in
-        that state — the arm should hold its position until a new target
-        arrives.
+        When ``params["move"]`` is ``True`` the target is stored for the IK
+        control loop and the ``teleop_target`` PoseStamped + TF are published
+        for visualization.  When ``move`` is ``False`` the phone is at rest;
+        we skip publishing so the arm holds its last commanded position.
         """
         if not params.get("move", False):
             return
+
+        # Store target for the IK control loop (under lock).
+        target_se3 = pin.SE3(pose[:3, :3].copy(), pose[:3, 3].copy())
+        with self._lock:
+            self._target_se3 = target_se3
+            self._last_move_time = self.get_clock().now()
 
         stamp = self.get_clock().now().to_msg()
 
@@ -274,6 +344,111 @@ class PhoneTeleopNode(Node):
         tf_msg.transform.rotation.y = float(quat[2])
         tf_msg.transform.rotation.z = float(quat[3])
         self._tf_broadcaster.sendTransform(tf_msg)
+
+    def _precompute_T_world_root(self) -> pin.SE3:
+        """Return the constant SE3 from Pinocchio's universe frame to ``root_frame``.
+
+        For a fixed-base arm ``root_frame`` (typically ``base_link``) is
+        connected to the URDF root (``world``) via a fixed joint, so this
+        transform is the same for every joint configuration.  It is used to
+        express FK results and IK targets in ``root_frame`` coordinates rather
+        than in Pinocchio's universe frame, which may have an arbitrary rotation
+        relative to the arm's base.
+        """
+        if not self._solver.model.existFrame(self._root_frame):
+            self.get_logger().warn(
+                f"root_frame '{self._root_frame}' not found in the Pinocchio model; "
+                "falling back to the universe frame.  Teleop axes may feel inverted."
+            )
+            return pin.SE3.Identity()
+        tmp_data = self._solver.model.createData()
+        pin.forwardKinematics(self._solver.model, tmp_data, pin.neutral(self._solver.model))
+        pin.updateFramePlacements(self._solver.model, tmp_data)
+        fid = self._solver.model.getFrameId(self._root_frame)
+        T = tmp_data.oMf[fid].copy()
+        self.get_logger().info(
+            f"root_frame '{self._root_frame}': translation={T.translation}, "
+            f"rpy={pin.rpy.matrixToRpy(T.rotation)}."
+        )
+        return T
+
+    # ------------------------------------------------------------------
+    # IK control loop (executor timer, MutuallyExclusiveCallbackGroup)
+    # ------------------------------------------------------------------
+    def _control_loop(self) -> None:
+        """Solve differential IK and stream joint commands at ``control_rate`` Hz.
+
+        The solver is seeded once from measured joint states at initialization.
+        Thereafter the IK integrates the configuration forward so the
+        AccelerationLimit smooths velocity transitions between ticks.
+
+        ``teleop.set_pose()`` is updated from the commanded EE pose (not the
+        measured one) so the phone bridge's delta is relative to where the arm
+        is being commanded to be, not where it happens to be measured.
+        """
+        dt = 1.0 / self._control_rate
+        now = self.get_clock().now()
+        q_cmd: np.ndarray | None = None
+        gripper: float | None = None
+
+        with self._lock:
+            if self._measured_q is None:
+                return  # no joint data yet
+
+            # Seed the solver once; let IK integrate thereafter.
+            if not self._ik_initialized:
+                self._solver.reset(self._measured_q)
+                self._ik_initialized = True
+                self.get_logger().info("IK solver initialized from measured joint states.")
+
+            # Seed teleop with the commanded EE pose expressed in root_frame
+            # coordinates so the phone's translational deltas are in the arm's
+            # natural coordinate frame rather than the URDF universe frame.
+            T_world_ee = self._solver.forward_kinematics()
+            T_root_ee = self._T_world_root.inverse() * T_world_ee
+            self._teleop.set_pose(_se3_to_mat(T_root_ee))
+
+            # Inactivity gate: stop solving when the phone has been at rest.
+            arm_active = self._last_move_time is not None and (
+                (now - self._last_move_time).nanoseconds * 1e-9 < self._inactivity_timeout
+            )
+
+            if not arm_active or self._target_se3 is None:
+                self._solver.set_zero_velocity()
+                return
+
+            # SE3 low-pass filter: geodesic step from the filtered target
+            # toward the latest raw target.
+            if self._target_filtered_se3 is None:
+                self._target_filtered_se3 = self._target_se3
+            else:
+                delta = pin.log6(self._target_filtered_se3.actInv(self._target_se3)).vector
+                self._target_filtered_se3 = self._target_filtered_se3 * pin.exp6(
+                    self._lowpass_alpha * delta
+                )
+
+            try:
+                # Convert the filtered target from root_frame back to world
+                # (Pinocchio universe) frame before passing it to the IK solver.
+                T_world_target = self._T_world_root * self._target_filtered_se3
+                q_cmd = self._solver.solve(T_world_target, dt)
+            except Exception as exc:
+                self.get_logger().warn(f"IK solve failed: {exc}")
+                return
+
+            gripper = self._gripper_position if self._has_gripper else None
+
+        if q_cmd is not None:
+            self._publish_command(q_cmd, gripper)
+
+    def _publish_command(self, q: np.ndarray, gripper: float | None) -> None:
+        """Publish a Float64MultiArray to the forward_position_controller."""
+        q_by_name = dict(zip(self._solver.joint_names, q, strict=True))
+        if self._has_gripper and gripper is not None:
+            q_by_name[self._gripper_joint] = gripper
+        cmd = Float64MultiArray()
+        cmd.data = [float(q_by_name[name]) for name in self._command_joints]
+        self._command_pub.publish(cmd)
 
 
 def main(args: list[str] | None = None) -> None:

--- a/pai_phone_teleop/pai_phone_teleop/phone_teleop_node.py
+++ b/pai_phone_teleop/pai_phone_teleop/phone_teleop_node.py
@@ -21,7 +21,7 @@ Architecture
 * ``_joint_state_cb`` (executor thread) — caches the latest measured joint
   positions and gripper angle under ``_lock``.  Does not touch the IK solver.
 * ``_teleop_cb`` (uvicorn/asyncio thread) — called on every WebSocket frame.
-  When the phone is moving, stores the commanded target (a 4×4 matrix in
+  When the phone is moving, stores the commanded target (a 4x4 matrix in
   ``root_frame``) for the control loop and publishes visualization topics.
 * ``_control_loop`` (executor timer, ``MutuallyExclusiveCallbackGroup``) —
   runs at ``control_rate`` Hz.  Seeds ``teleop.set_pose()`` with the current
@@ -92,7 +92,7 @@ def transient_local_qos(depth: int = 1) -> QoSProfile:
 
 
 def _se3_to_mat(se3: pin.SE3) -> np.ndarray:
-    """Convert a Pinocchio SE3 to a 4×4 homogeneous matrix."""
+    """Convert a Pinocchio SE3 to a 4x4 homogeneous matrix."""
     T = np.eye(4)
     T[:3, :3] = se3.rotation
     T[:3, 3] = se3.translation
@@ -167,14 +167,12 @@ class PhoneTeleopNode(Node):
         # Detect gripper and build the ordered command joint list.
         gripper_joint_param = self.get_parameter("gripper_joint").value
         self._gripper_joint: str | None = gripper_joint_param if gripper_joint_param else None
-        self._has_gripper = (
-            self._gripper_joint is not None
-            and self._solver.full_model.existJointName(self._gripper_joint)
+        self._has_gripper = self._gripper_joint is not None and self._solver.full_model.existJointName(
+            self._gripper_joint
         )
         if self._gripper_joint and not self._has_gripper:
             self.get_logger().warn(
-                f"gripper_joint '{self._gripper_joint}' not found in URDF; "
-                "gripper will be omitted from commands."
+                f"gripper_joint '{self._gripper_joint}' not found in URDF; gripper will be omitted from commands."
             )
         # Arm joints first, then gripper (matches forward_position_controller order).
         self._command_joints = list(self._solver.joint_names)
@@ -235,17 +233,13 @@ class PhoneTeleopNode(Node):
         self._button_b_held: bool = False
         self._gripper_engaged: bool = False
 
-        self._joint_state_sub = self.create_subscription(
-            JointState, self._joint_states_topic, self._joint_state_cb, 10
-        )
+        self._joint_state_sub = self.create_subscription(JointState, self._joint_states_topic, self._joint_state_cb, 10)
 
         # Fixed-rate IK solve and command publishing, isolated on its own
         # callback group so it is not starved by subscription callbacks.
         self._control_rate = float(self.get_parameter("control_rate").value)
         self._inactivity_timeout = float(self.get_parameter("inactivity_timeout").value)
-        self._lowpass_alpha = float(
-            np.clip(self.get_parameter("target_lowpass_alpha").value, 1e-3, 1.0)
-        )
+        self._lowpass_alpha = float(np.clip(self.get_parameter("target_lowpass_alpha").value, 1e-3, 1.0))
         self._control_group = MutuallyExclusiveCallbackGroup()
         self._control_timer = self.create_timer(
             1.0 / self._control_rate,
@@ -255,9 +249,7 @@ class PhoneTeleopNode(Node):
 
         # Start the blocking uvicorn server in a daemon thread so it dies
         # automatically when the process exits.
-        self._teleop_thread = threading.Thread(
-            target=self._teleop.run, daemon=True, name="teleop_server"
-        )
+        self._teleop_thread = threading.Thread(target=self._teleop.run, daemon=True, name="teleop_server")
         self._teleop_thread.start()
         self.get_logger().info(
             f"Phone teleop node ready. "
@@ -321,7 +313,7 @@ class PhoneTeleopNode(Node):
         """Store the phone-commanded target and publish visualization topics.
 
         Called by ``teleop.Teleop`` on every WebSocket frame.  ``pose`` is a
-        4×4 homogeneous matrix in ``root_frame`` coordinates.
+        4x4 homogeneous matrix in ``root_frame`` coordinates.
 
         When ``params["move"]`` is ``True`` the target is stored for the IK
         control loop and the ``teleop_target`` PoseStamped + TF are published
@@ -400,8 +392,7 @@ class PhoneTeleopNode(Node):
         fid = self._solver.model.getFrameId(self._root_frame)
         T = tmp_data.oMf[fid].copy()
         self.get_logger().info(
-            f"root_frame '{self._root_frame}': translation={T.translation}, "
-            f"rpy={pin.rpy.matrixToRpy(T.rotation)}."
+            f"root_frame '{self._root_frame}': translation={T.translation}, rpy={pin.rpy.matrixToRpy(T.rotation)}."
         )
         return T
 
@@ -471,9 +462,7 @@ class PhoneTeleopNode(Node):
                     self._target_filtered_se3 = self._target_se3
                 else:
                     delta = pin.log6(self._target_filtered_se3.actInv(self._target_se3)).vector
-                    self._target_filtered_se3 = self._target_filtered_se3 * pin.exp6(
-                        self._lowpass_alpha * delta
-                    )
+                    self._target_filtered_se3 = self._target_filtered_se3 * pin.exp6(self._lowpass_alpha * delta)
                 try:
                     # Convert the filtered target from root_frame back to world
                     # (Pinocchio universe) frame before passing it to the IK solver.

--- a/pai_phone_teleop/scripts/phone_teleop_node
+++ b/pai_phone_teleop/scripts/phone_teleop_node
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+# Copyright (C) 2026 Franco Cipollone
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Executable entry point for the integrated phone teleop node."""
+
+from pai_phone_teleop.phone_teleop_node import main
+
+if __name__ == "__main__":
+    main()

--- a/pixi.lock
+++ b/pixi.lock
@@ -342,6 +342,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/nettle-3.10.1-h4a9d5aa_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ninja-1.13.2-h171cf75_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/nlopt-2.10.1-np2py312h0f77346_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/nodejs-25.2.1-h728ac57_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/nspr-4.38-h29cc59b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/nss-3.118-h445c969_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-2.4.3-py312h33ff503_0.conda
@@ -1358,6 +1359,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/nettle-3.10.1-hfdb7b1a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ninja-1.13.2-hdc560ac_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/nlopt-2.10.1-np2py312h4394310_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/nodejs-25.2.1-he941dd9_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/nspr-4.38-h3ad9384_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/nss-3.118-h544fa81_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/numpy-2.4.3-py312h6615c27_0.conda
@@ -2365,6 +2367,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/nettle-3.10.1-h4a9d5aa_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ninja-1.13.2-h171cf75_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/nlopt-2.10.1-np2py312h0f77346_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/nodejs-25.2.1-h728ac57_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/nspr-4.38-h29cc59b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/nss-3.118-h445c969_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-2.4.3-py312h33ff503_0.conda
@@ -3380,6 +3383,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/nettle-3.10.1-hfdb7b1a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ninja-1.13.2-hdc560ac_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/nlopt-2.10.1-np2py312h4394310_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/nodejs-25.2.1-he941dd9_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/nspr-4.38-h3ad9384_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/nss-3.118-h544fa81_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/numpy-2.4.3-py312h6615c27_0.conda
@@ -4386,6 +4390,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/nettle-3.10.1-h4a9d5aa_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ninja-1.13.2-h171cf75_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/nlopt-2.10.1-np2py312h0f77346_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/nodejs-25.2.1-h728ac57_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/nspr-4.38-h29cc59b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/nss-3.118-h445c969_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-2.4.3-py312h33ff503_0.conda
@@ -5402,6 +5407,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/nettle-3.10.1-hfdb7b1a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ninja-1.13.2-hdc560ac_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/nlopt-2.10.1-np2py312h4394310_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/nodejs-25.2.1-he941dd9_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/nspr-4.38-h3ad9384_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/nss-3.118-h544fa81_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/numpy-2.4.3-py312h6615c27_0.conda
@@ -11226,6 +11232,31 @@ packages:
   - pkg:pypi/nlopt?source=hash-mapping
   size: 459408
   timestamp: 1773492086076
+- conda: https://conda.anaconda.org/conda-forge/linux-64/nodejs-25.2.1-h728ac57_2.conda
+  sha256: 553164f7b041eb3e4cb22c1e4e6f3da532632416d3a7fa4fa97fa48e64f1eb85
+  md5: 4c05dc4998537fabe4b545d9ef9d0a13
+  depends:
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.28,<3.0.a0
+  - icu >=78.2,<79.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - libuv >=1.51.0,<2.0a0
+  - libnghttp2 >=1.67.0,<2.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  - c-ares >=1.34.6,<2.0a0
+  - libsqlite >=3.51.2,<4.0a0
+  - libbrotlicommon >=1.2.0,<1.3.0a0
+  - libbrotlienc >=1.2.0,<1.3.0a0
+  - libbrotlidec >=1.2.0,<1.3.0a0
+  - openssl >=3.5.4,<4.0a0
+  - libabseil >=20250512.1,<20250513.0a0
+  - libabseil * cxx17*
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 17243215
+  timestamp: 1769159690239
 - conda: https://conda.anaconda.org/conda-forge/linux-64/nspr-4.38-h29cc59b_0.conda
   sha256: e3664264bd936c357523b55c71ed5a30263c6ba278d726a75b1eb112e6fb0b64
   md5: e235d5566c9cc8970eb2798dd4ecf62f
@@ -18115,6 +18146,31 @@ packages:
   - pkg:pypi/nlopt?source=hash-mapping
   size: 444636
   timestamp: 1773492091192
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/nodejs-25.2.1-he941dd9_2.conda
+  sha256: ad7fb9d274e9c3e8aa8cfebc1f28da40c945ec65904b09e98379f09a943939cb
+  md5: b37885466d7bcc2e03aac1b7e1443be2
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - openssl >=3.5.4,<4.0a0
+  - libsqlite >=3.51.2,<4.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - libabseil >=20250512.1,<20250513.0a0
+  - libabseil * cxx17*
+  - zstd >=1.5.7,<1.6.0a0
+  - icu >=78.2,<79.0a0
+  - libnghttp2 >=1.67.0,<2.0a0
+  - c-ares >=1.34.6,<2.0a0
+  - libuv >=1.51.0,<2.0a0
+  - libbrotlicommon >=1.2.0,<1.3.0a0
+  - libbrotlienc >=1.2.0,<1.3.0a0
+  - libbrotlidec >=1.2.0,<1.3.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 23172238
+  timestamp: 1769159712895
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/nspr-4.38-h3ad9384_0.conda
   sha256: 78a06e89285fef242e272998b292c1e621e3ee3dd4fba62ec014e503c7ec118f
   md5: 6dd4f07147774bf720075a210f8026b9

--- a/pixi.lock
+++ b/pixi.lock
@@ -911,13 +911,14 @@ environments:
       - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-zstd-image-transport-5.1.1-np2py312h2ed9cc7_15.conda
       - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-zstd-vendor-0.32.0-np2py312h2ed9cc7_15.conda
       - conda: https://prefix.dev/robostack-kilted/linux-64/ros2-distro-mutex-0.13.0-kilted_15.conda
-      - pypi: git+https://github.com/francocipollone/gz-mujoco?subdirectory=sdformat_mjcf&branch=francocipollone%2Favoid_eulerseq_compiler#2cb6e69c4a9eb16214508c6db6fc6bf6501cfec4
+      - pypi: git+https://github.com/francocipollone/gz-mujoco.git?subdirectory=sdformat_mjcf&branch=francocipollone%2Favoid_eulerseq_compiler#2cb6e69c4a9eb16214508c6db6fc6bf6501cfec4
       - pypi: https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/05/2c/ffc08c54c05cdce6fbed2aeebc46348dbe180c6d2c541c7af7ba0aa5f5f8/Farama_Notifications-0.0.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/05/6b/32f747947df2da6994e999492ab306a903659555dddc0fbdeb9d71f75e52/nvidia_cuda_nvrtc_cu12-12.8.93-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/07/bc/587a445451b253b285629263eb51c2d8e9bcea4fc97826266d186f96f558/pyserial-3.5-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/08/7e/36d548040e61337bf9182637a589c44da407a47a923ee88aec7f0e89867c/dm_env-1.6-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0a/fe/661043d1c263b0d9d10c6ff4e9c9745f3df9641c62b51f96a3473638e7ce/regex-2026.3.32-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0d/76/941cc9f73529988688a665a5c0ecff1112b3d95ab48f81db5f7606f522d3/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/0d/9b/a997b638fcd068ad6e4d53b8551a7d30fe8b404d6f1804abf1df69838932/nvidia_cuda_runtime_cu12-12.8.90-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl
@@ -925,9 +926,13 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/11/4f/426f91b96701ec2f37bb2b8cec664eff4f658a11f3fa9d94f0a887ea6d2b/xxhash-3.6.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/12/27/fb8d7338b4d551900fa3e580acbe7a0cf655d940e164cb5c00ec31961094/orderly_set-5.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/18/29/71729b4671f21e1eaa5d6573031ab810ad2936c8175f03f97f3ff164c802/websockets-16.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/18/a6/907a406bb7d359e6a63f99c313846d9eec4f7e6f7437809e03aa00fa3074/absl_py-2.4.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/1c/54/196d0c1db10af76baa4f64894448505d60d3cdf70ef92cbb35f46a4e4c71/starlette-1.2.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1e/77/dc8c558f7593132cf8fefec57c4f60c83b16941c574ac5f619abb3ae7933/dill-0.4.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1f/13/ee4e00f30e676b66ae65b4f08cb5bcbb8392c03f54f2d5413ea99a5d1c80/nvidia_cufft_cu12-11.3.3.83-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/22/24/ed72f68cbc1333ca9b9f2200aa048bb6658ae41709bc1caad4310f4bdffd/watchfiles-1.2.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/29/34/ccc711b6dc581e43b8d8d227e4173a8826994ee7b68d6b3d82291f307325/torchcodec-0.10.0-cp312-cp312-manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/2a/09/f8d8f8f31e4483c10a906437b4ce31bdf3d6d417b73fe33f1a8b59e34228/einops-0.8.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2a/2e/38d9824f8c6bb048c5ba21c6d4da54c29c162a46b58b3ef907a360a76d3e/diffusers-0.35.2-py3-none-any.whl
@@ -937,6 +942,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/2c/a5/da83046273d990f256cb79796a190bbf7ec999269705ddc609403f8c6b06/pyarrow-23.0.1-cp312-cp312-manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/31/a0/651f93d154cb72323358bf2bbae3e642bdb5d2f1bfc874d096f7cb159fa0/huggingface_hub-0.35.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/33/d1/8bb87d21e9aeb323cc03034f5eaf2c8f69841e40e4853c2627edf8111ed3/termcolor-3.3.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/34/db/b10e48aa8fff7407e67470363eac595018441cf32d5e1001567a7aeba5d2/websocket_client-1.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/3c/4c/781267da3188db679e601de18112021a5cb16506fe86b246e22c5401a9c4/hf_xet-1.4.2-cp37-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/3d/fe/89d77e424365280b79d99b3e1e7d606f5165af2f2ecfaf0c6d24c799d607/pandas-3.0.1-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl
@@ -953,7 +959,9 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/5a/3d/589663aeeacd59bb2f3e8596bfd3e81cf0fb18d70bb433199041f469771b/etils-1.14.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/5a/3f/efeb7c6801c46e11bd666a5180f0d615f74f72264212f74f39586c6fda9d/glfw-2.10.0-py2.py27.py3.py30.py31.py32.py33.py34.py35.py36.py37.py38.py39.py310.py311.py312.py313.py314-none-manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/5a/87/b70ad306ebb6f9b585f114d0ac2137d792b48be34d732d60e597c2f8465a/pydantic-2.12.5-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/5f/6f/e62b4dfc7ad6518e7eff2516f680d02a0f6eb62c0c212e152ca708a0085e/uvloop-0.22.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/5f/8e/c53d6f9a8bf3a86a635b58eeb675723f1b040f1665a0681467756c8989aa/feetech-servo-sdk-1.0.0.tar.gz
+      - pypi: https://files.pythonhosted.org/packages/61/7a/f38385f1b2d5f54221baf1db3d6371dc6eef8041d95abff39576c694e9d9/transforms3d-0.4.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/65/f3/107a22063bf27bdccf2024833d3445f4eea42b2e598abfbd46f6a63b6cb0/typing_inspect-0.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/66/3e/868e5c3364b6cee19ff3e1a122194fa4ce51def02c61023970442162859e/yarl-1.23.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
@@ -973,6 +981,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/84/03/0d3ce49e2505ae70cf43bc5bb3033955d2fc9f932163e84dc0779cc47f48/prompt_toolkit-3.0.52-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/85/48/9a13d2975803e8cf2777d5ed57b87a0b6ca2cc795f9a4f59796a910bfb80/nvidia_cusolver_cu12-11.7.3.90-py3-none-manylinux_2_27_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/88/fa/e1388bbcf24ef3274f45c0c1c7b501fd14971037c1b6ee23610553307497/uvicorn-0.49.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8c/d7/8ff98376b1acc4503253b685ea09981697385ce344d4e3935c2af49e044d/pfzy-0.3.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/93/66/0c02bd330e7d976f83fa68583d6198d76f23581bcbb5c0e98a6148f326e5/cuda_pathfinder-1.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/98/78/01c019cdb5d6498122777c1a43056ebb3ebfeef2076d9d026bfe15583b2b/click-8.3.1-py3-none-any.whl
@@ -1009,9 +1018,12 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/de/e4/1ba6f44e491c4eece978685230dde56b14d51a0365bc1b774ddaa94d14cd/pyopengl-3.1.10-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e0/6c/323c40671c6f1b3e02bb4a7404fbe2bf653190a56e63cf4b6a4f06e876bc/cmake-4.1.3-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/e0/82/45359b62a067409bd929ae8a56b8ed13e5a8c8a61194b3c236920999ab83/fastapi-0.136.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e3/a6/febbb8b8db0f58b38e44ad6cb946e6a255ae49b55f2e8543408fb7501ccd/httptools-0.8.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/e6/ab/fb21f4c939bb440104cc2b396d3be1d9b7a9fd3c6c2a53d98c45b3d7c954/fsspec-2026.2.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e7/05/c19819d5e3d95294a6f5947fb9b9629efb316b96de511b418c53d245aae6/cycler-0.12.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ec/0e/2bed3a6d225921e31bf9200a9c4470f7bc3a12b940bfbca22fa7aa9dfa0e/dm_control-1.0.38-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/f2/d1/45c79fcbf2551f2035c375e81d560c4ac46a5bbdb1622583b559eedcfc4e/teleop-0.1.5-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f3/8d/5e5be3ced1d12966fefb5c4ea3b2a5b480afcea36406559442c6e31d4a48/multidict-6.7.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/f5/86/0b9c8f56398b4fc85f8e99279907c258413a297e5603f8f2537fe5806e51/rerun_sdk-0.26.2-cp39-abi3-manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/f6/74/86a07f1d0f42998ca31312f998bd3b9a7eff7f52378f4f270c8679c77fb9/nvidia_nvjitlink_cu12-12.8.93-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl
@@ -1911,20 +1923,25 @@ environments:
       - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-zstd-image-transport-5.1.1-np2py312h61f2ce4_15.conda
       - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-zstd-vendor-0.32.0-np2py312h61f2ce4_15.conda
       - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros2-distro-mutex-0.13.0-kilted_15.conda
-      - pypi: git+https://github.com/francocipollone/gz-mujoco?subdirectory=sdformat_mjcf&branch=francocipollone%2Favoid_eulerseq_compiler#2cb6e69c4a9eb16214508c6db6fc6bf6501cfec4
+      - pypi: git+https://github.com/francocipollone/gz-mujoco.git?subdirectory=sdformat_mjcf&branch=francocipollone%2Favoid_eulerseq_compiler#2cb6e69c4a9eb16214508c6db6fc6bf6501cfec4
       - pypi: https://files.pythonhosted.org/packages/00/f9/7638f5cc82ec8a7aa005de48622eecc3ed7c9854b96ba15bd76b7fd27574/matplotlib-3.10.8-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/05/2c/ffc08c54c05cdce6fbed2aeebc46348dbe180c6d2c541c7af7ba0aa5f5f8/Farama_Notifications-0.0.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/07/bc/587a445451b253b285629263eb51c2d8e9bcea4fc97826266d186f96f558/pyserial-3.5-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/08/7e/36d548040e61337bf9182637a589c44da407a47a923ee88aec7f0e89867c/dm_env-1.6-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0c/1d/1d39e90ef6348a0964caa7c5c4d05f3bae2c51ab429eb7d2e21198ac9b6d/grpcio-1.73.1-cp312-cp312-manylinux_2_17_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0f/15/5bf3b99495fb160b63f95972b81750f18f7f4e02ad051373b669d17d44f2/aiohappyeyeballs-2.6.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/12/27/fb8d7338b4d551900fa3e580acbe7a0cf655d940e164cb5c00ec31961094/orderly_set-5.5.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/13/01/b32a967c56fb3e3e5be3db52c3d3b87fa4513aa367d8ed1ad96d42952e5f/watchfiles-1.2.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/13/29/53d8d98799ab32418fd4ba6834d6a5749c31f56160d3c87f52a7219887e9/rerun_sdk-0.26.2-cp39-abi3-manylinux_2_28_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/18/a6/907a406bb7d359e6a63f99c313846d9eec4f7e6f7437809e03aa00fa3074/absl_py-2.4.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/1c/54/196d0c1db10af76baa4f64894448505d60d3cdf70ef92cbb35f46a4e4c71/starlette-1.2.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1e/77/dc8c558f7593132cf8fefec57c4f60c83b16941c574ac5f619abb3ae7933/dill-0.4.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/24/68/a6ac446820273e71aa762fa21cdcc09861edd3536ff47c5cd3b7afb10eeb/uvloop-0.22.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/2a/09/f8d8f8f31e4483c10a906437b4ce31bdf3d6d417b73fe33f1a8b59e34228/einops-0.8.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2a/2e/38d9824f8c6bb048c5ba21c6d4da54c29c162a46b58b3ef907a360a76d3e/diffusers-0.35.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl
@@ -1934,6 +1951,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/31/a0/651f93d154cb72323358bf2bbae3e642bdb5d2f1bfc874d096f7cb159fa0/huggingface_hub-0.35.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/33/d1/8bb87d21e9aeb323cc03034f5eaf2c8f69841e40e4853c2627edf8111ed3/termcolor-3.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/33/e7/1925bfbc563c39c1d2e82501d8372734a5c725e53ac3b31b4c2d081e895b/imageio_ffmpeg-0.6.0-py3-none-manylinux2014_aarch64.whl
+      - pypi: https://files.pythonhosted.org/packages/34/db/b10e48aa8fff7407e67470363eac595018441cf32d5e1001567a7aeba5d2/websocket_client-1.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/3e/99/33b0281ac9a0b0c251195e6ce6cb310efa2f84ee117a15e9997fc2f9503b/wandb-0.24.2-py3-none-manylinux_2_28_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/43/e3/7d92a15f894aa0c9c4b49b8ee9ac9850d6e63b03c9c32c0367a13ae62209/mpmath-1.3.0-py3-none-any.whl
@@ -1948,6 +1966,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/5a/3d/589663aeeacd59bb2f3e8596bfd3e81cf0fb18d70bb433199041f469771b/etils-1.14.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/5a/87/b70ad306ebb6f9b585f114d0ac2137d792b48be34d732d60e597c2f8465a/pydantic-2.12.5-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/5f/8e/c53d6f9a8bf3a86a635b58eeb675723f1b040f1665a0681467756c8989aa/feetech-servo-sdk-1.0.0.tar.gz
+      - pypi: https://files.pythonhosted.org/packages/61/7a/f38385f1b2d5f54221baf1db3d6371dc6eef8041d95abff39576c694e9d9/transforms3d-0.4.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/65/f3/107a22063bf27bdccf2024833d3445f4eea42b2e598abfbd46f6a63b6cb0/typing_inspect-0.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/68/47/d6cf4a39ecf6c7705f887a46f6ef5c8455b44ad9eb0d391aa7e8a2ff7fea/hf_xet-1.4.2-cp37-abi3-manylinux_2_28_aarch64.whl
@@ -1963,9 +1982,11 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/84/03/0d3ce49e2505ae70cf43bc5bb3033955d2fc9f932163e84dc0779cc47f48/prompt_toolkit-3.0.52-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/88/7c/3d841c366620e906d54430817531b877ba646310296df42ef697308c2705/pyarrow-23.0.1-cp312-cp312-manylinux_2_28_aarch64.whl
+      - pypi: https://files.pythonhosted.org/packages/88/fa/e1388bbcf24ef3274f45c0c1c7b501fd14971037c1b6ee23610553307497/uvicorn-0.49.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8c/d7/8ff98376b1acc4503253b685ea09981697385ce344d4e3935c2af49e044d/pfzy-0.3.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8e/a2/cd7885bc9959421065a6fae0fe67b6c55becdeda4e69b873e52976f9a9f0/hf_transfer-0.1.9-cp38-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/8f/83/f61505a05109ef3293dfb1ff594d13d64a2324ac3482be2cedc2be818256/frozenlist-1.8.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
+      - pypi: https://files.pythonhosted.org/packages/97/bb/21c36b7dbbafc85d2d480cd65df02a1dc93bf76d97147605a8e27ff9409d/websockets-16.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/98/78/01c019cdb5d6498122777c1a43056ebb3ebfeef2076d9d026bfe15583b2b/click-8.3.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/99/30/58260ed98e6ff7f90ba84442c1ddd758c9170d70327394a6227b310cd60f/yarl-1.23.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/9a/3c/c17fb3ca2d9c3acff52e30b309f538586f9f5b9c9cf454f3845fc9af4881/certifi-2026.2.25-py3-none-any.whl
@@ -1977,6 +1998,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/a8/37/bdca6613c2e3c58c7421891d80cc3efa1d32e882f7c4a7ee6039c3fc951a/charset_normalizer-3.4.6-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/ad/95/2ca4dd1efff4456f44baf4c4a980cfea6f6fb8729912a760ec9bf912876b/labmaze-1.0.6-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/b0/e5/247d094108e42ac26363ab8dc57f168840cf7c05774b40ffeb0d78868fcc/datasets-4.8.4-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b7/e4/f90a0df0b83beff265b7e3b65f2a4cefd95792d4be0ac3e16049f2acd3c2/httptools-0.8.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/c1/d4/59e74daffcb57a07668852eeeb6035af9f32cbfd7a1d2511f17d2fe6a738/smmap-5.0.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c4/9a/a83083b230d352ee5d205757b74006dbe084448ca45e3bc5ca99215b1e55/draccus-0.10.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c8/2f/cebfcdb60fd6a9b0f6b47a9337198bcbad6fbe15e68189b7011fd914911f/kiwisolver-1.5.0-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl
@@ -1992,10 +2014,12 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/de/e4/1ba6f44e491c4eece978685230dde56b14d51a0365bc1b774ddaa94d14cd/pyopengl-3.1.10-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e0/82/45359b62a067409bd929ae8a56b8ed13e5a8c8a61194b3c236920999ab83/fastapi-0.136.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e6/ab/fb21f4c939bb440104cc2b396d3be1d9b7a9fd3c6c2a53d98c45b3d7c954/fsspec-2026.2.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e7/05/c19819d5e3d95294a6f5947fb9b9629efb316b96de511b418c53d245aae6/cycler-0.12.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ec/0e/2bed3a6d225921e31bf9200a9c4470f7bc3a12b940bfbca22fa7aa9dfa0e/dm_control-1.0.38-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f1/06/578ffed52c2296f93d7fd2d844cabfa92be51a587c38c8afbb8ae449ca89/safetensors-0.7.0-cp38-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
+      - pypi: https://files.pythonhosted.org/packages/f2/d1/45c79fcbf2551f2035c375e81d560c4ac46a5bbdb1622583b559eedcfc4e/teleop-0.1.5-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f3/f8/2d781e5e71d02fc829487e775ccb1185e72f95340d05f2e84eb57a11e093/av-15.1.0-cp312-cp312-manylinux_2_28_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/f8/62/d9ba6323b9202dd2fe166beab8a86d29465c41a0288cbe229fac60c1ab8d/jsonlines-4.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fb/76/641ae371508676492379f16e2fa48f4e2c11741bd63c48be4b12a6b09cba/aiosignal-1.4.0-py3-none-any.whl
@@ -2909,12 +2933,13 @@ environments:
       - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-zstd-image-transport-5.1.1-np2py312h2ed9cc7_15.conda
       - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-zstd-vendor-0.32.0-np2py312h2ed9cc7_15.conda
       - conda: https://prefix.dev/robostack-kilted/linux-64/ros2-distro-mutex-0.13.0-kilted_15.conda
-      - pypi: git+https://github.com/francocipollone/gz-mujoco?subdirectory=sdformat_mjcf&branch=francocipollone%2Favoid_eulerseq_compiler#2cb6e69c4a9eb16214508c6db6fc6bf6501cfec4
+      - pypi: git+https://github.com/francocipollone/gz-mujoco.git?subdirectory=sdformat_mjcf&branch=francocipollone%2Favoid_eulerseq_compiler#2cb6e69c4a9eb16214508c6db6fc6bf6501cfec4
       - pypi: https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/05/2c/ffc08c54c05cdce6fbed2aeebc46348dbe180c6d2c541c7af7ba0aa5f5f8/Farama_Notifications-0.0.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/05/6b/32f747947df2da6994e999492ab306a903659555dddc0fbdeb9d71f75e52/nvidia_cuda_nvrtc_cu12-12.8.93-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/07/bc/587a445451b253b285629263eb51c2d8e9bcea4fc97826266d186f96f558/pyserial-3.5-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/08/7e/36d548040e61337bf9182637a589c44da407a47a923ee88aec7f0e89867c/dm_env-1.6-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0d/76/941cc9f73529988688a665a5c0ecff1112b3d95ab48f81db5f7606f522d3/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/0d/9b/a997b638fcd068ad6e4d53b8551a7d30fe8b404d6f1804abf1df69838932/nvidia_cuda_runtime_cu12-12.8.90-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl
@@ -2922,10 +2947,14 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/11/4f/426f91b96701ec2f37bb2b8cec664eff4f658a11f3fa9d94f0a887ea6d2b/xxhash-3.6.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/12/27/fb8d7338b4d551900fa3e580acbe7a0cf655d940e164cb5c00ec31961094/orderly_set-5.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/18/29/71729b4671f21e1eaa5d6573031ab810ad2936c8175f03f97f3ff164c802/websockets-16.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/18/a6/907a406bb7d359e6a63f99c313846d9eec4f7e6f7437809e03aa00fa3074/absl_py-2.4.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/1c/54/196d0c1db10af76baa4f64894448505d60d3cdf70ef92cbb35f46a4e4c71/starlette-1.2.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1e/77/dc8c558f7593132cf8fefec57c4f60c83b16941c574ac5f619abb3ae7933/dill-0.4.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1f/13/ee4e00f30e676b66ae65b4f08cb5bcbb8392c03f54f2d5413ea99a5d1c80/nvidia_cufft_cu12-11.3.3.83-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/22/24/ed72f68cbc1333ca9b9f2200aa048bb6658ae41709bc1caad4310f4bdffd/watchfiles-1.2.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/29/34/ccc711b6dc581e43b8d8d227e4173a8826994ee7b68d6b3d82291f307325/torchcodec-0.10.0-cp312-cp312-manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/2a/09/f8d8f8f31e4483c10a906437b4ce31bdf3d6d417b73fe33f1a8b59e34228/einops-0.8.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2a/2e/38d9824f8c6bb048c5ba21c6d4da54c29c162a46b58b3ef907a360a76d3e/diffusers-0.35.2-py3-none-any.whl
@@ -2936,6 +2965,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/31/a0/651f93d154cb72323358bf2bbae3e642bdb5d2f1bfc874d096f7cb159fa0/huggingface_hub-0.35.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/33/d1/8bb87d21e9aeb323cc03034f5eaf2c8f69841e40e4853c2627edf8111ed3/termcolor-3.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/34/c6/b8298394a8926f8af21c059f4ec794b61f9cf64ade561184027b94110639/datasets-4.8.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/34/db/b10e48aa8fff7407e67470363eac595018441cf32d5e1001567a7aeba5d2/websocket_client-1.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/38/0e/27be9fdef66e72d64c0cdc3cc2823101b80585f8119b5c112c2e8f5f7dab/anyio-4.12.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/3c/4c/781267da3188db679e601de18112021a5cb16506fe86b246e22c5401a9c4/hf_xet-1.4.2-cp37-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
@@ -2952,7 +2982,9 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/5a/3d/589663aeeacd59bb2f3e8596bfd3e81cf0fb18d70bb433199041f469771b/etils-1.14.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/5a/3f/efeb7c6801c46e11bd666a5180f0d615f74f72264212f74f39586c6fda9d/glfw-2.10.0-py2.py27.py3.py30.py31.py32.py33.py34.py35.py36.py37.py38.py39.py310.py311.py312.py313.py314-none-manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/5a/87/b70ad306ebb6f9b585f114d0ac2137d792b48be34d732d60e597c2f8465a/pydantic-2.12.5-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/5f/6f/e62b4dfc7ad6518e7eff2516f680d02a0f6eb62c0c212e152ca708a0085e/uvloop-0.22.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/5f/8e/c53d6f9a8bf3a86a635b58eeb675723f1b040f1665a0681467756c8989aa/feetech-servo-sdk-1.0.0.tar.gz
+      - pypi: https://files.pythonhosted.org/packages/61/7a/f38385f1b2d5f54221baf1db3d6371dc6eef8041d95abff39576c694e9d9/transforms3d-0.4.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/65/f3/107a22063bf27bdccf2024833d3445f4eea42b2e598abfbd46f6a63b6cb0/typing_inspect-0.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/66/3e/868e5c3364b6cee19ff3e1a122194fa4ce51def02c61023970442162859e/yarl-1.23.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
@@ -2973,6 +3005,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/85/48/9a13d2975803e8cf2777d5ed57b87a0b6ca2cc795f9a4f59796a910bfb80/nvidia_cusolver_cu12-11.7.3.90-py3-none-manylinux_2_27_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/86/f6/a62cbbf13f0ac80a70f71b1672feba90fdb21fd7abd8dbf25c0105fb6fa3/aiohttp-3.13.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/88/fa/e1388bbcf24ef3274f45c0c1c7b501fd14971037c1b6ee23610553307497/uvicorn-0.49.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8c/d7/8ff98376b1acc4503253b685ea09981697385ce344d4e3935c2af49e044d/pfzy-0.3.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/98/78/01c019cdb5d6498122777c1a43056ebb3ebfeef2076d9d026bfe15583b2b/click-8.3.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9a/3c/c17fb3ca2d9c3acff52e30b309f538586f9f5b9c9cf454f3845fc9af4881/certifi-2026.2.25-py3-none-any.whl
@@ -3007,9 +3040,12 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/de/e4/1ba6f44e491c4eece978685230dde56b14d51a0365bc1b774ddaa94d14cd/pyopengl-3.1.10-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e0/6c/323c40671c6f1b3e02bb4a7404fbe2bf653190a56e63cf4b6a4f06e876bc/cmake-4.1.3-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/e0/82/45359b62a067409bd929ae8a56b8ed13e5a8c8a61194b3c236920999ab83/fastapi-0.136.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e3/a6/febbb8b8db0f58b38e44ad6cb946e6a255ae49b55f2e8543408fb7501ccd/httptools-0.8.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/e6/ab/fb21f4c939bb440104cc2b396d3be1d9b7a9fd3c6c2a53d98c45b3d7c954/fsspec-2026.2.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e7/05/c19819d5e3d95294a6f5947fb9b9629efb316b96de511b418c53d245aae6/cycler-0.12.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ec/0e/2bed3a6d225921e31bf9200a9c4470f7bc3a12b940bfbca22fa7aa9dfa0e/dm_control-1.0.38-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/f2/d1/45c79fcbf2551f2035c375e81d560c4ac46a5bbdb1622583b559eedcfc4e/teleop-0.1.5-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f3/8d/5e5be3ced1d12966fefb5c4ea3b2a5b480afcea36406559442c6e31d4a48/multidict-6.7.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/f5/86/0b9c8f56398b4fc85f8e99279907c258413a297e5603f8f2537fe5806e51/rerun_sdk-0.26.2-cp39-abi3-manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/f6/74/86a07f1d0f42998ca31312f998bd3b9a7eff7f52378f4f270c8679c77fb9/nvidia_nvjitlink_cu12-12.8.93-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl
@@ -3908,21 +3944,26 @@ environments:
       - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-zstd-image-transport-5.1.1-np2py312h61f2ce4_15.conda
       - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-zstd-vendor-0.32.0-np2py312h61f2ce4_15.conda
       - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros2-distro-mutex-0.13.0-kilted_15.conda
-      - pypi: git+https://github.com/francocipollone/gz-mujoco?subdirectory=sdformat_mjcf&branch=francocipollone%2Favoid_eulerseq_compiler#2cb6e69c4a9eb16214508c6db6fc6bf6501cfec4
+      - pypi: git+https://github.com/francocipollone/gz-mujoco.git?subdirectory=sdformat_mjcf&branch=francocipollone%2Favoid_eulerseq_compiler#2cb6e69c4a9eb16214508c6db6fc6bf6501cfec4
       - pypi: https://files.pythonhosted.org/packages/00/f9/7638f5cc82ec8a7aa005de48622eecc3ed7c9854b96ba15bd76b7fd27574/matplotlib-3.10.8-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/05/2c/ffc08c54c05cdce6fbed2aeebc46348dbe180c6d2c541c7af7ba0aa5f5f8/Farama_Notifications-0.0.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/07/bc/587a445451b253b285629263eb51c2d8e9bcea4fc97826266d186f96f558/pyserial-3.5-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/08/7e/36d548040e61337bf9182637a589c44da407a47a923ee88aec7f0e89867c/dm_env-1.6-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0c/1d/1d39e90ef6348a0964caa7c5c4d05f3bae2c51ab429eb7d2e21198ac9b6d/grpcio-1.73.1-cp312-cp312-manylinux_2_17_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0f/15/5bf3b99495fb160b63f95972b81750f18f7f4e02ad051373b669d17d44f2/aiohappyeyeballs-2.6.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/12/27/fb8d7338b4d551900fa3e580acbe7a0cf655d940e164cb5c00ec31961094/orderly_set-5.5.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/13/01/b32a967c56fb3e3e5be3db52c3d3b87fa4513aa367d8ed1ad96d42952e5f/watchfiles-1.2.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/13/29/53d8d98799ab32418fd4ba6834d6a5749c31f56160d3c87f52a7219887e9/rerun_sdk-0.26.2-cp39-abi3-manylinux_2_28_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/18/a6/907a406bb7d359e6a63f99c313846d9eec4f7e6f7437809e03aa00fa3074/absl_py-2.4.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/1c/54/196d0c1db10af76baa4f64894448505d60d3cdf70ef92cbb35f46a4e4c71/starlette-1.2.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1e/77/dc8c558f7593132cf8fefec57c4f60c83b16941c574ac5f619abb3ae7933/dill-0.4.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/24/68/a6ac446820273e71aa762fa21cdcc09861edd3536ff47c5cd3b7afb10eeb/uvloop-0.22.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/2a/09/f8d8f8f31e4483c10a906437b4ce31bdf3d6d417b73fe33f1a8b59e34228/einops-0.8.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2a/2e/38d9824f8c6bb048c5ba21c6d4da54c29c162a46b58b3ef907a360a76d3e/diffusers-0.35.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl
@@ -3933,6 +3974,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/33/d1/8bb87d21e9aeb323cc03034f5eaf2c8f69841e40e4853c2627edf8111ed3/termcolor-3.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/33/e7/1925bfbc563c39c1d2e82501d8372734a5c725e53ac3b31b4c2d081e895b/imageio_ffmpeg-0.6.0-py3-none-manylinux2014_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/34/c6/b8298394a8926f8af21c059f4ec794b61f9cf64ade561184027b94110639/datasets-4.8.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/34/db/b10e48aa8fff7407e67470363eac595018441cf32d5e1001567a7aeba5d2/websocket_client-1.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/38/0e/27be9fdef66e72d64c0cdc3cc2823101b80585f8119b5c112c2e8f5f7dab/anyio-4.12.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/3e/99/33b0281ac9a0b0c251195e6ce6cb310efa2f84ee117a15e9997fc2f9503b/wandb-0.24.2-py3-none-manylinux_2_28_aarch64.whl
@@ -3946,6 +3988,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/5a/3d/589663aeeacd59bb2f3e8596bfd3e81cf0fb18d70bb433199041f469771b/etils-1.14.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/5a/87/b70ad306ebb6f9b585f114d0ac2137d792b48be34d732d60e597c2f8465a/pydantic-2.12.5-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/5f/8e/c53d6f9a8bf3a86a635b58eeb675723f1b040f1665a0681467756c8989aa/feetech-servo-sdk-1.0.0.tar.gz
+      - pypi: https://files.pythonhosted.org/packages/61/7a/f38385f1b2d5f54221baf1db3d6371dc6eef8041d95abff39576c694e9d9/transforms3d-0.4.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/65/f3/107a22063bf27bdccf2024833d3445f4eea42b2e598abfbd46f6a63b6cb0/typing_inspect-0.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/68/47/d6cf4a39ecf6c7705f887a46f6ef5c8455b44ad9eb0d391aa7e8a2ff7fea/hf_xet-1.4.2-cp37-abi3-manylinux_2_28_aarch64.whl
@@ -3961,10 +4004,12 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/84/03/0d3ce49e2505ae70cf43bc5bb3033955d2fc9f932163e84dc0779cc47f48/prompt_toolkit-3.0.52-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/88/7c/3d841c366620e906d54430817531b877ba646310296df42ef697308c2705/pyarrow-23.0.1-cp312-cp312-manylinux_2_28_aarch64.whl
+      - pypi: https://files.pythonhosted.org/packages/88/fa/e1388bbcf24ef3274f45c0c1c7b501fd14971037c1b6ee23610553307497/uvicorn-0.49.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8c/d7/8ff98376b1acc4503253b685ea09981697385ce344d4e3935c2af49e044d/pfzy-0.3.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8d/a8/5a35dc56a06a2c90d4742cbf35294396907027f80eea696637945a106f25/aiohttp-3.13.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/8e/a2/cd7885bc9959421065a6fae0fe67b6c55becdeda4e69b873e52976f9a9f0/hf_transfer-0.1.9-cp38-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/8f/83/f61505a05109ef3293dfb1ff594d13d64a2324ac3482be2cedc2be818256/frozenlist-1.8.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
+      - pypi: https://files.pythonhosted.org/packages/97/bb/21c36b7dbbafc85d2d480cd65df02a1dc93bf76d97147605a8e27ff9409d/websockets-16.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/98/78/01c019cdb5d6498122777c1a43056ebb3ebfeef2076d9d026bfe15583b2b/click-8.3.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/99/30/58260ed98e6ff7f90ba84442c1ddd758c9170d70327394a6227b310cd60f/yarl-1.23.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/9a/3c/c17fb3ca2d9c3acff52e30b309f538586f9f5b9c9cf454f3845fc9af4881/certifi-2026.2.25-py3-none-any.whl
@@ -3976,6 +4021,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/a5/f5/397b61091120a9ca5001041dd7bf76c385b3bfd67a0e5bcb74b852bd22a4/evdev-1.9.3.tar.gz
       - pypi: https://files.pythonhosted.org/packages/a8/37/bdca6613c2e3c58c7421891d80cc3efa1d32e882f7c4a7ee6039c3fc951a/charset_normalizer-3.4.6-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/ad/95/2ca4dd1efff4456f44baf4c4a980cfea6f6fb8729912a760ec9bf912876b/labmaze-1.0.6-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
+      - pypi: https://files.pythonhosted.org/packages/b7/e4/f90a0df0b83beff265b7e3b65f2a4cefd95792d4be0ac3e16049f2acd3c2/httptools-0.8.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/c1/d4/59e74daffcb57a07668852eeeb6035af9f32cbfd7a1d2511f17d2fe6a738/smmap-5.0.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c4/9a/a83083b230d352ee5d205757b74006dbe084448ca45e3bc5ca99215b1e55/draccus-0.10.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c8/2f/cebfcdb60fd6a9b0f6b47a9337198bcbad6fbe15e68189b7011fd914911f/kiwisolver-1.5.0-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl
@@ -3989,10 +4035,12 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/dd/c9/8cc8d850b35ab5650ff6756a1cb85286e2000b66c97520b29c1587455344/regex-2026.2.28-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/de/e4/1ba6f44e491c4eece978685230dde56b14d51a0365bc1b774ddaa94d14cd/pyopengl-3.1.10-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e0/82/45359b62a067409bd929ae8a56b8ed13e5a8c8a61194b3c236920999ab83/fastapi-0.136.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e6/ab/fb21f4c939bb440104cc2b396d3be1d9b7a9fd3c6c2a53d98c45b3d7c954/fsspec-2026.2.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e7/05/c19819d5e3d95294a6f5947fb9b9629efb316b96de511b418c53d245aae6/cycler-0.12.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ec/0e/2bed3a6d225921e31bf9200a9c4470f7bc3a12b940bfbca22fa7aa9dfa0e/dm_control-1.0.38-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f1/06/578ffed52c2296f93d7fd2d844cabfa92be51a587c38c8afbb8ae449ca89/safetensors-0.7.0-cp38-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
+      - pypi: https://files.pythonhosted.org/packages/f2/d1/45c79fcbf2551f2035c375e81d560c4ac46a5bbdb1622583b559eedcfc4e/teleop-0.1.5-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f3/f8/2d781e5e71d02fc829487e775ccb1185e72f95340d05f2e84eb57a11e093/av-15.1.0-cp312-cp312-manylinux_2_28_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/f8/62/d9ba6323b9202dd2fe166beab8a86d29465c41a0288cbe229fac60c1ab8d/jsonlines-4.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fb/76/641ae371508676492379f16e2fa48f4e2c11741bd63c48be4b12a6b09cba/aiosignal-1.4.0-py3-none-any.whl
@@ -4907,13 +4955,14 @@ environments:
       - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-zstd-image-transport-5.1.1-np2py312h2ed9cc7_15.conda
       - conda: https://prefix.dev/robostack-kilted/linux-64/ros-kilted-zstd-vendor-0.32.0-np2py312h2ed9cc7_15.conda
       - conda: https://prefix.dev/robostack-kilted/linux-64/ros2-distro-mutex-0.13.0-kilted_15.conda
-      - pypi: git+https://github.com/francocipollone/gz-mujoco?subdirectory=sdformat_mjcf&branch=francocipollone%2Favoid_eulerseq_compiler#2cb6e69c4a9eb16214508c6db6fc6bf6501cfec4
+      - pypi: git+https://github.com/francocipollone/gz-mujoco.git?subdirectory=sdformat_mjcf&branch=francocipollone%2Favoid_eulerseq_compiler#2cb6e69c4a9eb16214508c6db6fc6bf6501cfec4
       - pypi: https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/05/2c/ffc08c54c05cdce6fbed2aeebc46348dbe180c6d2c541c7af7ba0aa5f5f8/Farama_Notifications-0.0.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/05/6b/32f747947df2da6994e999492ab306a903659555dddc0fbdeb9d71f75e52/nvidia_cuda_nvrtc_cu12-12.8.93-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/07/bc/587a445451b253b285629263eb51c2d8e9bcea4fc97826266d186f96f558/pyserial-3.5-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/08/7e/36d548040e61337bf9182637a589c44da407a47a923ee88aec7f0e89867c/dm_env-1.6-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0a/fe/661043d1c263b0d9d10c6ff4e9c9745f3df9641c62b51f96a3473638e7ce/regex-2026.3.32-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0d/76/941cc9f73529988688a665a5c0ecff1112b3d95ab48f81db5f7606f522d3/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/0d/9b/a997b638fcd068ad6e4d53b8551a7d30fe8b404d6f1804abf1df69838932/nvidia_cuda_runtime_cu12-12.8.90-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl
@@ -4921,9 +4970,13 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/11/4f/426f91b96701ec2f37bb2b8cec664eff4f658a11f3fa9d94f0a887ea6d2b/xxhash-3.6.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/12/27/fb8d7338b4d551900fa3e580acbe7a0cf655d940e164cb5c00ec31961094/orderly_set-5.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/18/29/71729b4671f21e1eaa5d6573031ab810ad2936c8175f03f97f3ff164c802/websockets-16.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/18/a6/907a406bb7d359e6a63f99c313846d9eec4f7e6f7437809e03aa00fa3074/absl_py-2.4.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/1c/54/196d0c1db10af76baa4f64894448505d60d3cdf70ef92cbb35f46a4e4c71/starlette-1.2.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1e/77/dc8c558f7593132cf8fefec57c4f60c83b16941c574ac5f619abb3ae7933/dill-0.4.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1f/13/ee4e00f30e676b66ae65b4f08cb5bcbb8392c03f54f2d5413ea99a5d1c80/nvidia_cufft_cu12-11.3.3.83-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/22/24/ed72f68cbc1333ca9b9f2200aa048bb6658ae41709bc1caad4310f4bdffd/watchfiles-1.2.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/29/34/ccc711b6dc581e43b8d8d227e4173a8826994ee7b68d6b3d82291f307325/torchcodec-0.10.0-cp312-cp312-manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/2a/09/f8d8f8f31e4483c10a906437b4ce31bdf3d6d417b73fe33f1a8b59e34228/einops-0.8.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2a/2e/38d9824f8c6bb048c5ba21c6d4da54c29c162a46b58b3ef907a360a76d3e/diffusers-0.35.2-py3-none-any.whl
@@ -4933,6 +4986,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/2c/a5/da83046273d990f256cb79796a190bbf7ec999269705ddc609403f8c6b06/pyarrow-23.0.1-cp312-cp312-manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/31/a0/651f93d154cb72323358bf2bbae3e642bdb5d2f1bfc874d096f7cb159fa0/huggingface_hub-0.35.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/33/d1/8bb87d21e9aeb323cc03034f5eaf2c8f69841e40e4853c2627edf8111ed3/termcolor-3.3.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/34/db/b10e48aa8fff7407e67470363eac595018441cf32d5e1001567a7aeba5d2/websocket_client-1.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/3c/4c/781267da3188db679e601de18112021a5cb16506fe86b246e22c5401a9c4/hf_xet-1.4.2-cp37-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/3d/fe/89d77e424365280b79d99b3e1e7d606f5165af2f2ecfaf0c6d24c799d607/pandas-3.0.1-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl
@@ -4949,7 +5003,9 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/5a/3d/589663aeeacd59bb2f3e8596bfd3e81cf0fb18d70bb433199041f469771b/etils-1.14.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/5a/3f/efeb7c6801c46e11bd666a5180f0d615f74f72264212f74f39586c6fda9d/glfw-2.10.0-py2.py27.py3.py30.py31.py32.py33.py34.py35.py36.py37.py38.py39.py310.py311.py312.py313.py314-none-manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/5a/87/b70ad306ebb6f9b585f114d0ac2137d792b48be34d732d60e597c2f8465a/pydantic-2.12.5-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/5f/6f/e62b4dfc7ad6518e7eff2516f680d02a0f6eb62c0c212e152ca708a0085e/uvloop-0.22.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/5f/8e/c53d6f9a8bf3a86a635b58eeb675723f1b040f1665a0681467756c8989aa/feetech-servo-sdk-1.0.0.tar.gz
+      - pypi: https://files.pythonhosted.org/packages/61/7a/f38385f1b2d5f54221baf1db3d6371dc6eef8041d95abff39576c694e9d9/transforms3d-0.4.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/65/f3/107a22063bf27bdccf2024833d3445f4eea42b2e598abfbd46f6a63b6cb0/typing_inspect-0.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/66/3e/868e5c3364b6cee19ff3e1a122194fa4ce51def02c61023970442162859e/yarl-1.23.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
@@ -4969,6 +5025,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/84/03/0d3ce49e2505ae70cf43bc5bb3033955d2fc9f932163e84dc0779cc47f48/prompt_toolkit-3.0.52-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/85/48/9a13d2975803e8cf2777d5ed57b87a0b6ca2cc795f9a4f59796a910bfb80/nvidia_cusolver_cu12-11.7.3.90-py3-none-manylinux_2_27_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/88/fa/e1388bbcf24ef3274f45c0c1c7b501fd14971037c1b6ee23610553307497/uvicorn-0.49.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8c/d7/8ff98376b1acc4503253b685ea09981697385ce344d4e3935c2af49e044d/pfzy-0.3.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/93/66/0c02bd330e7d976f83fa68583d6198d76f23581bcbb5c0e98a6148f326e5/cuda_pathfinder-1.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/98/78/01c019cdb5d6498122777c1a43056ebb3ebfeef2076d9d026bfe15583b2b/click-8.3.1-py3-none-any.whl
@@ -5005,9 +5062,12 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/de/e4/1ba6f44e491c4eece978685230dde56b14d51a0365bc1b774ddaa94d14cd/pyopengl-3.1.10-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e0/6c/323c40671c6f1b3e02bb4a7404fbe2bf653190a56e63cf4b6a4f06e876bc/cmake-4.1.3-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/e0/82/45359b62a067409bd929ae8a56b8ed13e5a8c8a61194b3c236920999ab83/fastapi-0.136.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e3/a6/febbb8b8db0f58b38e44ad6cb946e6a255ae49b55f2e8543408fb7501ccd/httptools-0.8.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/e6/ab/fb21f4c939bb440104cc2b396d3be1d9b7a9fd3c6c2a53d98c45b3d7c954/fsspec-2026.2.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e7/05/c19819d5e3d95294a6f5947fb9b9629efb316b96de511b418c53d245aae6/cycler-0.12.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ec/0e/2bed3a6d225921e31bf9200a9c4470f7bc3a12b940bfbca22fa7aa9dfa0e/dm_control-1.0.38-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/f2/d1/45c79fcbf2551f2035c375e81d560c4ac46a5bbdb1622583b559eedcfc4e/teleop-0.1.5-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f3/8d/5e5be3ced1d12966fefb5c4ea3b2a5b480afcea36406559442c6e31d4a48/multidict-6.7.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/f5/86/0b9c8f56398b4fc85f8e99279907c258413a297e5603f8f2537fe5806e51/rerun_sdk-0.26.2-cp39-abi3-manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/f6/74/86a07f1d0f42998ca31312f998bd3b9a7eff7f52378f4f270c8679c77fb9/nvidia_nvjitlink_cu12-12.8.93-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl
@@ -5907,20 +5967,25 @@ environments:
       - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-zstd-image-transport-5.1.1-np2py312h61f2ce4_15.conda
       - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros-kilted-zstd-vendor-0.32.0-np2py312h61f2ce4_15.conda
       - conda: https://prefix.dev/robostack-kilted/linux-aarch64/ros2-distro-mutex-0.13.0-kilted_15.conda
-      - pypi: git+https://github.com/francocipollone/gz-mujoco?subdirectory=sdformat_mjcf&branch=francocipollone%2Favoid_eulerseq_compiler#2cb6e69c4a9eb16214508c6db6fc6bf6501cfec4
+      - pypi: git+https://github.com/francocipollone/gz-mujoco.git?subdirectory=sdformat_mjcf&branch=francocipollone%2Favoid_eulerseq_compiler#2cb6e69c4a9eb16214508c6db6fc6bf6501cfec4
       - pypi: https://files.pythonhosted.org/packages/00/f9/7638f5cc82ec8a7aa005de48622eecc3ed7c9854b96ba15bd76b7fd27574/matplotlib-3.10.8-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/05/2c/ffc08c54c05cdce6fbed2aeebc46348dbe180c6d2c541c7af7ba0aa5f5f8/Farama_Notifications-0.0.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/07/bc/587a445451b253b285629263eb51c2d8e9bcea4fc97826266d186f96f558/pyserial-3.5-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/08/7e/36d548040e61337bf9182637a589c44da407a47a923ee88aec7f0e89867c/dm_env-1.6-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0c/1d/1d39e90ef6348a0964caa7c5c4d05f3bae2c51ab429eb7d2e21198ac9b6d/grpcio-1.73.1-cp312-cp312-manylinux_2_17_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0f/15/5bf3b99495fb160b63f95972b81750f18f7f4e02ad051373b669d17d44f2/aiohappyeyeballs-2.6.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/12/27/fb8d7338b4d551900fa3e580acbe7a0cf655d940e164cb5c00ec31961094/orderly_set-5.5.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/13/01/b32a967c56fb3e3e5be3db52c3d3b87fa4513aa367d8ed1ad96d42952e5f/watchfiles-1.2.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/13/29/53d8d98799ab32418fd4ba6834d6a5749c31f56160d3c87f52a7219887e9/rerun_sdk-0.26.2-cp39-abi3-manylinux_2_28_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/18/a6/907a406bb7d359e6a63f99c313846d9eec4f7e6f7437809e03aa00fa3074/absl_py-2.4.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/1c/54/196d0c1db10af76baa4f64894448505d60d3cdf70ef92cbb35f46a4e4c71/starlette-1.2.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1e/77/dc8c558f7593132cf8fefec57c4f60c83b16941c574ac5f619abb3ae7933/dill-0.4.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/24/68/a6ac446820273e71aa762fa21cdcc09861edd3536ff47c5cd3b7afb10eeb/uvloop-0.22.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/2a/09/f8d8f8f31e4483c10a906437b4ce31bdf3d6d417b73fe33f1a8b59e34228/einops-0.8.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2a/2e/38d9824f8c6bb048c5ba21c6d4da54c29c162a46b58b3ef907a360a76d3e/diffusers-0.35.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl
@@ -5930,6 +5995,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/31/a0/651f93d154cb72323358bf2bbae3e642bdb5d2f1bfc874d096f7cb159fa0/huggingface_hub-0.35.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/33/d1/8bb87d21e9aeb323cc03034f5eaf2c8f69841e40e4853c2627edf8111ed3/termcolor-3.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/33/e7/1925bfbc563c39c1d2e82501d8372734a5c725e53ac3b31b4c2d081e895b/imageio_ffmpeg-0.6.0-py3-none-manylinux2014_aarch64.whl
+      - pypi: https://files.pythonhosted.org/packages/34/db/b10e48aa8fff7407e67470363eac595018441cf32d5e1001567a7aeba5d2/websocket_client-1.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/3e/99/33b0281ac9a0b0c251195e6ce6cb310efa2f84ee117a15e9997fc2f9503b/wandb-0.24.2-py3-none-manylinux_2_28_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/43/e3/7d92a15f894aa0c9c4b49b8ee9ac9850d6e63b03c9c32c0367a13ae62209/mpmath-1.3.0-py3-none-any.whl
@@ -5944,6 +6010,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/5a/3d/589663aeeacd59bb2f3e8596bfd3e81cf0fb18d70bb433199041f469771b/etils-1.14.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/5a/87/b70ad306ebb6f9b585f114d0ac2137d792b48be34d732d60e597c2f8465a/pydantic-2.12.5-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/5f/8e/c53d6f9a8bf3a86a635b58eeb675723f1b040f1665a0681467756c8989aa/feetech-servo-sdk-1.0.0.tar.gz
+      - pypi: https://files.pythonhosted.org/packages/61/7a/f38385f1b2d5f54221baf1db3d6371dc6eef8041d95abff39576c694e9d9/transforms3d-0.4.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/65/f3/107a22063bf27bdccf2024833d3445f4eea42b2e598abfbd46f6a63b6cb0/typing_inspect-0.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/68/47/d6cf4a39ecf6c7705f887a46f6ef5c8455b44ad9eb0d391aa7e8a2ff7fea/hf_xet-1.4.2-cp37-abi3-manylinux_2_28_aarch64.whl
@@ -5959,9 +6026,11 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/84/03/0d3ce49e2505ae70cf43bc5bb3033955d2fc9f932163e84dc0779cc47f48/prompt_toolkit-3.0.52-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/88/7c/3d841c366620e906d54430817531b877ba646310296df42ef697308c2705/pyarrow-23.0.1-cp312-cp312-manylinux_2_28_aarch64.whl
+      - pypi: https://files.pythonhosted.org/packages/88/fa/e1388bbcf24ef3274f45c0c1c7b501fd14971037c1b6ee23610553307497/uvicorn-0.49.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8c/d7/8ff98376b1acc4503253b685ea09981697385ce344d4e3935c2af49e044d/pfzy-0.3.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8e/a2/cd7885bc9959421065a6fae0fe67b6c55becdeda4e69b873e52976f9a9f0/hf_transfer-0.1.9-cp38-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/8f/83/f61505a05109ef3293dfb1ff594d13d64a2324ac3482be2cedc2be818256/frozenlist-1.8.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
+      - pypi: https://files.pythonhosted.org/packages/97/bb/21c36b7dbbafc85d2d480cd65df02a1dc93bf76d97147605a8e27ff9409d/websockets-16.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/98/78/01c019cdb5d6498122777c1a43056ebb3ebfeef2076d9d026bfe15583b2b/click-8.3.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/99/30/58260ed98e6ff7f90ba84442c1ddd758c9170d70327394a6227b310cd60f/yarl-1.23.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/9a/3c/c17fb3ca2d9c3acff52e30b309f538586f9f5b9c9cf454f3845fc9af4881/certifi-2026.2.25-py3-none-any.whl
@@ -5973,6 +6042,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/a8/37/bdca6613c2e3c58c7421891d80cc3efa1d32e882f7c4a7ee6039c3fc951a/charset_normalizer-3.4.6-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/ad/95/2ca4dd1efff4456f44baf4c4a980cfea6f6fb8729912a760ec9bf912876b/labmaze-1.0.6-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/b0/e5/247d094108e42ac26363ab8dc57f168840cf7c05774b40ffeb0d78868fcc/datasets-4.8.4-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b7/e4/f90a0df0b83beff265b7e3b65f2a4cefd95792d4be0ac3e16049f2acd3c2/httptools-0.8.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/c1/d4/59e74daffcb57a07668852eeeb6035af9f32cbfd7a1d2511f17d2fe6a738/smmap-5.0.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c4/9a/a83083b230d352ee5d205757b74006dbe084448ca45e3bc5ca99215b1e55/draccus-0.10.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c8/2f/cebfcdb60fd6a9b0f6b47a9337198bcbad6fbe15e68189b7011fd914911f/kiwisolver-1.5.0-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl
@@ -5988,10 +6058,12 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/de/e4/1ba6f44e491c4eece978685230dde56b14d51a0365bc1b774ddaa94d14cd/pyopengl-3.1.10-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e0/82/45359b62a067409bd929ae8a56b8ed13e5a8c8a61194b3c236920999ab83/fastapi-0.136.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e6/ab/fb21f4c939bb440104cc2b396d3be1d9b7a9fd3c6c2a53d98c45b3d7c954/fsspec-2026.2.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e7/05/c19819d5e3d95294a6f5947fb9b9629efb316b96de511b418c53d245aae6/cycler-0.12.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ec/0e/2bed3a6d225921e31bf9200a9c4470f7bc3a12b940bfbca22fa7aa9dfa0e/dm_control-1.0.38-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f1/06/578ffed52c2296f93d7fd2d844cabfa92be51a587c38c8afbb8ae449ca89/safetensors-0.7.0-cp38-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
+      - pypi: https://files.pythonhosted.org/packages/f2/d1/45c79fcbf2551f2035c375e81d560c4ac46a5bbdb1622583b559eedcfc4e/teleop-0.1.5-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f3/f8/2d781e5e71d02fc829487e775ccb1185e72f95340d05f2e84eb57a11e093/av-15.1.0-cp312-cp312-manylinux_2_28_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/f8/62/d9ba6323b9202dd2fe166beab8a86d29465c41a0288cbe229fac60c1ab8d/jsonlines-4.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fb/76/641ae371508676492379f16e2fa48f4e2c11741bd63c48be4b12a6b09cba/aiosignal-1.4.0-py3-none-any.whl
@@ -36172,7 +36244,7 @@ packages:
   license: BSD-3-Clause
   size: 2343
   timestamp: 1769480922749
-- pypi: git+https://github.com/francocipollone/gz-mujoco?subdirectory=sdformat_mjcf&branch=francocipollone%2Favoid_eulerseq_compiler#2cb6e69c4a9eb16214508c6db6fc6bf6501cfec4
+- pypi: git+https://github.com/francocipollone/gz-mujoco.git?subdirectory=sdformat_mjcf&branch=francocipollone%2Favoid_eulerseq_compiler#2cb6e69c4a9eb16214508c6db6fc6bf6501cfec4
   name: sdformat-mjcf
   version: 0.1.2
   requires_dist:
@@ -36231,6 +36303,13 @@ packages:
   version: 2026.3.32
   sha256: f54840bea73541652f1170dc63402a5b776fc851ad36a842da9e5163c1f504a0
   requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl
+  name: python-dotenv
+  version: 1.2.2
+  sha256: 1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a
+  requires_dist:
+  - click>=5.0 ; extra == 'cli'
+  requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/0c/1d/1d39e90ef6348a0964caa7c5c4d05f3bae2c51ab429eb7d2e21198ac9b6d/grpcio-1.73.1-cp312-cp312-manylinux_2_17_aarch64.whl
   name: grpcio
   version: 1.73.1
@@ -36286,6 +36365,13 @@ packages:
   - pytest-cov~=6.0.0 ; extra == 'test'
   - python-dotenv~=1.0.0 ; extra == 'test'
   requires_python: '>=3.8'
+- pypi: https://files.pythonhosted.org/packages/13/01/b32a967c56fb3e3e5be3db52c3d3b87fa4513aa367d8ed1ad96d42952e5f/watchfiles-1.2.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
+  name: watchfiles
+  version: 1.2.0
+  sha256: 8f70d8b291ef6e88d19b1f297a6905ddb978888d9272b0d05e6f53309856bcfc
+  requires_dist:
+  - anyio>=3.0.0
+  requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/13/29/53d8d98799ab32418fd4ba6834d6a5749c31f56160d3c87f52a7219887e9/rerun_sdk-0.26.2-cp39-abi3-manylinux_2_28_aarch64.whl
   name: rerun-sdk
   version: 0.26.2
@@ -36319,10 +36405,28 @@ packages:
   - requests ; extra == 'telegram'
   - ipywidgets>=6 ; extra == 'notebook'
   requires_python: '>=3.7'
+- pypi: https://files.pythonhosted.org/packages/18/29/71729b4671f21e1eaa5d6573031ab810ad2936c8175f03f97f3ff164c802/websockets-16.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
+  name: websockets
+  version: '16.0'
+  sha256: 9b5aca38b67492ef518a8ab76851862488a478602229112c4b0d58d63a7a4d5c
+  requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/18/a6/907a406bb7d359e6a63f99c313846d9eec4f7e6f7437809e03aa00fa3074/absl_py-2.4.0-py3-none-any.whl
   name: absl-py
   version: 2.4.0
   sha256: 88476fd881ca8aab94ffa78b7b6c632a782ab3ba1cd19c9bd423abc4fb4cd28d
+  requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/1c/54/196d0c1db10af76baa4f64894448505d60d3cdf70ef92cbb35f46a4e4c71/starlette-1.2.1-py3-none-any.whl
+  name: starlette
+  version: 1.2.1
+  sha256: 4de0082d08c8f6764a85a54cf1120d6939507a19905c7768acad2a9f875d2b89
+  requires_dist:
+  - anyio>=3.6.2,<5
+  - typing-extensions>=4.10.0 ; python_full_version < '3.13'
+  - httpx>=0.27.0,<0.29.0 ; extra == 'full'
+  - itsdangerous ; extra == 'full'
+  - jinja2 ; extra == 'full'
+  - python-multipart>=0.0.18 ; extra == 'full'
+  - pyyaml ; extra == 'full'
   requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/1e/77/dc8c558f7593132cf8fefec57c4f60c83b16941c574ac5f619abb3ae7933/dill-0.4.1-py3-none-any.whl
   name: dill
@@ -36332,6 +36436,11 @@ packages:
   - objgraph>=1.7.2 ; extra == 'graph'
   - gprof2dot>=2022.7.29 ; extra == 'profile'
   requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl
+  name: annotated-doc
+  version: 0.0.4
+  sha256: 571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320
+  requires_python: '>=3.8'
 - pypi: https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl
   name: requests
   version: 2.32.5
@@ -36351,6 +36460,30 @@ packages:
   requires_dist:
   - nvidia-nvjitlink-cu12
   requires_python: '>=3'
+- pypi: https://files.pythonhosted.org/packages/22/24/ed72f68cbc1333ca9b9f2200aa048bb6658ae41709bc1caad4310f4bdffd/watchfiles-1.2.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+  name: watchfiles
+  version: 1.2.0
+  sha256: e53a384f76b631c3ae5334ce6a52f0baa3a911eb94a4eac7f160079868b716d5
+  requires_dist:
+  - anyio>=3.0.0
+  requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/24/68/a6ac446820273e71aa762fa21cdcc09861edd3536ff47c5cd3b7afb10eeb/uvloop-0.22.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
+  name: uvloop
+  version: 0.22.1
+  sha256: 700e674a166ca5778255e0e1dc4e9d79ab2acc57b9171b79e65feba7184b3370
+  requires_dist:
+  - aiohttp>=3.10.5 ; extra == 'test'
+  - flake8~=6.1 ; extra == 'test'
+  - psutil ; extra == 'test'
+  - pycodestyle~=2.11.0 ; extra == 'test'
+  - pyopenssl~=25.3.0 ; extra == 'test'
+  - mypy>=0.800 ; extra == 'test'
+  - setuptools>=60 ; extra == 'dev'
+  - cython~=3.0 ; extra == 'dev'
+  - sphinx~=4.1.2 ; extra == 'docs'
+  - sphinxcontrib-asyncio~=0.3.0 ; extra == 'docs'
+  - sphinx-rtd-theme~=0.5.2 ; extra == 'docs'
+  requires_python: '>=3.8.1'
 - pypi: https://files.pythonhosted.org/packages/29/34/ccc711b6dc581e43b8d8d227e4173a8826994ee7b68d6b3d82291f307325/torchcodec-0.10.0-cp312-cp312-manylinux_2_28_x86_64.whl
   name: torchcodec
   version: 0.10.0
@@ -36827,6 +36960,19 @@ packages:
   - nibabel>=5.3.2 ; extra == 'nibabel'
   - ipyniivue==2.4.2 ; extra == 'nibabel'
   requires_python: '>=3.10.0'
+- pypi: https://files.pythonhosted.org/packages/34/db/b10e48aa8fff7407e67470363eac595018441cf32d5e1001567a7aeba5d2/websocket_client-1.9.0-py3-none-any.whl
+  name: websocket-client
+  version: 1.9.0
+  sha256: af248a825037ef591efbf6ed20cc5faa03d3b47b9e5a2230a529eeee1c1fc3ef
+  requires_dist:
+  - pytest ; extra == 'test'
+  - websockets ; extra == 'test'
+  - python-socks ; extra == 'optional'
+  - wsaccel ; extra == 'optional'
+  - sphinx>=6.0 ; extra == 'docs'
+  - sphinx-rtd-theme>=1.1.0 ; extra == 'docs'
+  - myst-parser>=2.0.0 ; extra == 'docs'
+  requires_python: '>=3.9'
 - pypi: https://files.pythonhosted.org/packages/38/0e/27be9fdef66e72d64c0cdc3cc2823101b80585f8119b5c112c2e8f5f7dab/anyio-4.12.1-py3-none-any.whl
   name: anyio
   version: 4.12.1
@@ -37354,12 +37500,36 @@ packages:
   - email-validator>=2.0.0 ; extra == 'email'
   - tzdata ; python_full_version >= '3.9' and sys_platform == 'win32' and extra == 'timezone'
   requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/5f/6f/e62b4dfc7ad6518e7eff2516f680d02a0f6eb62c0c212e152ca708a0085e/uvloop-0.22.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+  name: uvloop
+  version: 0.22.1
+  sha256: 7b5b1ac819a3f946d3b2ee07f09149578ae76066d70b44df3fa990add49a82e4
+  requires_dist:
+  - aiohttp>=3.10.5 ; extra == 'test'
+  - flake8~=6.1 ; extra == 'test'
+  - psutil ; extra == 'test'
+  - pycodestyle~=2.11.0 ; extra == 'test'
+  - pyopenssl~=25.3.0 ; extra == 'test'
+  - mypy>=0.800 ; extra == 'test'
+  - setuptools>=60 ; extra == 'dev'
+  - cython~=3.0 ; extra == 'dev'
+  - sphinx~=4.1.2 ; extra == 'docs'
+  - sphinxcontrib-asyncio~=0.3.0 ; extra == 'docs'
+  - sphinx-rtd-theme~=0.5.2 ; extra == 'docs'
+  requires_python: '>=3.8.1'
 - pypi: https://files.pythonhosted.org/packages/5f/8e/c53d6f9a8bf3a86a635b58eeb675723f1b040f1665a0681467756c8989aa/feetech-servo-sdk-1.0.0.tar.gz
   name: feetech-servo-sdk
   version: 1.0.0
   sha256: d4d3832e4b1b22a8222133a414db9f868224c2fb639426a1b11d96ddfe84e69c
   requires_dist:
   - pyserial
+- pypi: https://files.pythonhosted.org/packages/61/7a/f38385f1b2d5f54221baf1db3d6371dc6eef8041d95abff39576c694e9d9/transforms3d-0.4.2-py3-none-any.whl
+  name: transforms3d
+  version: 0.4.2
+  sha256: 1c70399d9e9473ecc23311fd947f727f7c69ed0b063244828c383aa1aefa5941
+  requires_dist:
+  - numpy>=1.15
+  requires_python: '>=3.6'
 - pypi: https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl
   name: attrs
   version: 26.1.0
@@ -37720,6 +37890,22 @@ packages:
   version: 23.0.1
   sha256: 86ff03fb9f1a320266e0de855dee4b17da6794c595d207f89bba40d16b5c78b9
   requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/88/fa/e1388bbcf24ef3274f45c0c1c7b501fd14971037c1b6ee23610553307497/uvicorn-0.49.0-py3-none-any.whl
+  name: uvicorn
+  version: 0.49.0
+  sha256: ba3d14c3ee7e41c6c654c46c9eb489d33213cdd30aa1696eab1374337c13f68f
+  requires_dist:
+  - click>=7.0
+  - h11>=0.8
+  - typing-extensions>=4.0 ; python_full_version < '3.11'
+  - colorama>=0.4 ; sys_platform == 'win32' and extra == 'standard'
+  - httptools>=0.8.0 ; extra == 'standard'
+  - python-dotenv>=0.13 ; extra == 'standard'
+  - pyyaml>=5.1 ; extra == 'standard'
+  - uvloop>=0.15.1 ; platform_python_implementation != 'PyPy' and sys_platform != 'cygwin' and sys_platform != 'win32' and extra == 'standard'
+  - watchfiles>=0.20 ; extra == 'standard'
+  - websockets>=10.4 ; extra == 'standard'
+  requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/8c/d7/8ff98376b1acc4503253b685ea09981697385ce344d4e3935c2af49e044d/pfzy-0.3.4-py3-none-any.whl
   name: pfzy
   version: 0.3.4
@@ -37763,6 +37949,11 @@ packages:
   name: cuda-pathfinder
   version: 1.5.0
   sha256: 498f90a9e9de36044a7924742aecce11c50c49f735f1bc53e05aa46de9ea4110
+  requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/97/bb/21c36b7dbbafc85d2d480cd65df02a1dc93bf76d97147605a8e27ff9409d/websockets-16.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
+  name: websockets
+  version: '16.0'
+  sha256: e0334872c0a37b606418ac52f6ab9cfd17317ac26365f7f65e203e2d0d0d359f
   requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/98/78/01c019cdb5d6498122777c1a43056ebb3ebfeef2076d9d026bfe15583b2b/click-8.3.1-py3-none-any.whl
   name: click
@@ -38254,6 +38445,11 @@ packages:
   version: 3.4.5
   sha256: 042f2500f24c021db8a06c5eec2539027d57460e1c1a762055a6554f72c369bd
   requires_python: '>=3'
+- pypi: https://files.pythonhosted.org/packages/b7/e4/f90a0df0b83beff265b7e3b65f2a4cefd95792d4be0ac3e16049f2acd3c2/httptools-0.8.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
+  name: httptools
+  version: 0.8.0
+  sha256: 425f83884fd6343828d8c565f046cb72b6d19063f6924093e11bcd8e1548cd09
+  requires_python: '>=3.9'
 - pypi: https://files.pythonhosted.org/packages/ba/51/e123d997aa098c61d029f76663dedbfb9bc8dcf8c60cbd6adbe42f76d049/nvidia_cudnn_cu12-9.10.2.21-py3-none-manylinux_2_27_x86_64.whl
   name: nvidia-cudnn-cu12
   version: 9.10.2.21
@@ -38765,6 +38961,49 @@ packages:
   version: 4.1.3
   sha256: 81f11b72bc59cbe547d9f283487ef0519bf68176edffcdfa1a4dc5a52f292369
   requires_python: '>=3.8'
+- pypi: https://files.pythonhosted.org/packages/e0/82/45359b62a067409bd929ae8a56b8ed13e5a8c8a61194b3c236920999ab83/fastapi-0.136.3-py3-none-any.whl
+  name: fastapi
+  version: 0.136.3
+  sha256: 3d2a69bdf04b7e9f3afa292c3bc7a98816bbfafa10bc9b45f3f3700d2f761620
+  requires_dist:
+  - starlette>=0.46.0
+  - pydantic>=2.9.0
+  - typing-extensions>=4.8.0
+  - typing-inspection>=0.4.2
+  - annotated-doc>=0.0.2
+  - fastapi-cli[standard]>=0.0.8 ; extra == 'standard'
+  - fastar>=0.9.0 ; extra == 'standard'
+  - httpx>=0.23.0,<1.0.0 ; extra == 'standard'
+  - jinja2>=3.1.5 ; extra == 'standard'
+  - python-multipart>=0.0.18 ; extra == 'standard'
+  - email-validator>=2.0.0 ; extra == 'standard'
+  - uvicorn[standard]>=0.12.0 ; extra == 'standard'
+  - pydantic-settings>=2.0.0 ; extra == 'standard'
+  - pydantic-extra-types>=2.0.0 ; extra == 'standard'
+  - fastapi-cli[standard-no-fastapi-cloud-cli]>=0.0.8 ; extra == 'standard-no-fastapi-cloud-cli'
+  - httpx>=0.23.0,<1.0.0 ; extra == 'standard-no-fastapi-cloud-cli'
+  - jinja2>=3.1.5 ; extra == 'standard-no-fastapi-cloud-cli'
+  - python-multipart>=0.0.18 ; extra == 'standard-no-fastapi-cloud-cli'
+  - email-validator>=2.0.0 ; extra == 'standard-no-fastapi-cloud-cli'
+  - uvicorn[standard]>=0.12.0 ; extra == 'standard-no-fastapi-cloud-cli'
+  - pydantic-settings>=2.0.0 ; extra == 'standard-no-fastapi-cloud-cli'
+  - pydantic-extra-types>=2.0.0 ; extra == 'standard-no-fastapi-cloud-cli'
+  - fastapi-cli[standard]>=0.0.8 ; extra == 'all'
+  - httpx>=0.23.0,<1.0.0 ; extra == 'all'
+  - jinja2>=3.1.5 ; extra == 'all'
+  - python-multipart>=0.0.18 ; extra == 'all'
+  - itsdangerous>=1.1.0 ; extra == 'all'
+  - pyyaml>=5.3.1 ; extra == 'all'
+  - email-validator>=2.0.0 ; extra == 'all'
+  - uvicorn[standard]>=0.12.0 ; extra == 'all'
+  - pydantic-settings>=2.0.0 ; extra == 'all'
+  - pydantic-extra-types>=2.0.0 ; extra == 'all'
+  requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/e3/a6/febbb8b8db0f58b38e44ad6cb946e6a255ae49b55f2e8543408fb7501ccd/httptools-0.8.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
+  name: httptools
+  version: 0.8.0
+  sha256: b15fc622b0f869d19207c4089a501d9bcc63ca5e071ffdd2f03f922df882dcb2
+  requires_python: '>=3.9'
 - pypi: https://files.pythonhosted.org/packages/e6/ab/fb21f4c939bb440104cc2b396d3be1d9b7a9fd3c6c2a53d98c45b3d7c954/fsspec-2026.2.0-py3-none-any.whl
   name: fsspec
   version: 2026.2.0
@@ -38951,6 +39190,19 @@ packages:
   - safetensors[testing] ; extra == 'all'
   - safetensors[all] ; extra == 'dev'
   requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/f2/d1/45c79fcbf2551f2035c375e81d560c4ac46a5bbdb1622583b559eedcfc4e/teleop-0.1.5-py3-none-any.whl
+  name: teleop
+  version: 0.1.5
+  sha256: 75c3e63bb9eed1ea8ca32b48086cea45fa5ae3eb022dd0dcf0d615cf0b0d58dc
+  requires_dist:
+  - fastapi
+  - uvicorn[standard]
+  - numpy
+  - transforms3d
+  - pytest
+  - requests
+  - websocket-client
+  - pin ; extra == 'utils'
 - pypi: https://files.pythonhosted.org/packages/f3/8d/5e5be3ced1d12966fefb5c4ea3b2a5b480afcea36406559442c6e31d4a48/multidict-6.7.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
   name: multidict
   version: 6.7.1

--- a/pixi.toml
+++ b/pixi.toml
@@ -155,6 +155,12 @@ huggingface-hub = "*"
 # LeRobot 0.4.x imports scipy.fftpack.idct; SciPy 2.0 removed fftpack re-exports.
 scipy = ">=1.11.0,<2"
 lerobot = { version = "==0.4.4", extras = ["feetech", "async"] }
+# pai_phone_teleop pulls in the upstream SpesRobotics/teleop package, which
+# provides the WebXR phone bridge (python3 -m teleop.ros2). Its hard deps
+# (uvicorn + fastapi<1.0) are listed explicitly here.
+teleop = "==0.1.5"
+fastapi = "<1.0"
+uvicorn = "*"
 # SDF→MJCF converter: used at launch time to convert the canonical SDF world to MuJoCo format.
 # Installed from source (conda-forge 0.1.2 is too old for sdformat15).
 # TODO(francocipollone): Point to upstream once the PR is merged: https://github.com/gazebosim/gz-mujoco/pull/125

--- a/pixi.toml
+++ b/pixi.toml
@@ -150,6 +150,7 @@ ros-kilted-usb-cam = "*"
 ros-kilted-camera-calibration = ">=6.0.11,<7"
 # Differential inverse kinematics (Pink) + Pinocchio backend for the interactive marker IK demo.
 pink = ">=3.1,<5"
+nodejs = ">=18"
 
 [pypi-dependencies]
 huggingface-hub = "*"

--- a/pixi.toml
+++ b/pixi.toml
@@ -39,6 +39,7 @@ so-arm-real = { cmd = ["ros2", "launch", "pai_bringup", "so_arm_real_bringup.lau
 so-arm-gz = { cmd = ["ros2", "launch", "pai_bringup", "so_arm_gz_bringup.launch.py"] }
 so-arm-mujoco = { cmd = ["ros2", "launch", "pai_bringup", "so_arm_mujoco_bringup.launch.py"] }
 so-arm-rviz-ik = { cmd = ["ros2", "launch", "pai_rviz_teleop", "interactive_ik_demo.launch.py"] }
+so-arm-phone-ik = { cmd = ["ros2", "launch", "pai_phone_teleop", "phone_teleop.launch.py"] }
 rerun-viz = { cmd = ["ros2", "launch", "pai_rerun_visualizer", "visualizer.launch.py"] }
 rosetta-record-mujoco = { cmd = [
   "ros2",


### PR DESCRIPTION
### Summary

Phone-based 6-DoF pose teleoperation for the SO-ARM101.

A single ROS 2 node embeds the upstream [`teleop`](https://github.com/SpesRobotics/teleop)
WebXR bridge together with Pinocchio forward kinematics and Pink differential
IK. The arm tracks the phone's 6-DoF pose in real time by streaming joint
positions to the `forward_position_controller`.

### How to run

1. Launch any `pai_bringup` bringup (real / mujoco / gz), e.g.:

   ```bash
   pixi run so-arm-gz
   ```

2. Launch the phone teleop:

   ```bash
   pixi run so-arm-phone-ik
   ```

3. Open the HTTPS URL logged to stdout (default `https://<host>:4443/`) on a
   phone with a WebXR-capable browser (e.g. Chrome on Android).


4. Press `START` button for initiating the teleoperation and keep press the `HOLD TO MOVE` button while moving the phone to teleoperate.

> [!NOTE]
> Recommendation: Keep the phone >vertical and steady and then press `START`.

> [!Important]
> When you press the start button the XR localization starts using the orientation registered at initialization. If you press START while holding the phone in a weird orientation it might be tricky to start teleoperating correctly as it is easy to get confused.

