### PR TITLE
Support inverted gripper position convention in phone teleop

### DIFF
--- a/pai_phone_teleop/pai_phone_teleop/phone_teleop_node.py
+++ b/pai_phone_teleop/pai_phone_teleop/phone_teleop_node.py
@@ -108,6 +108,7 @@ class PhoneTeleopNode(Node):
         self._gripper_open = float(self.get_parameter("gripper_open_position").value)
         self._gripper_closed = float(self.get_parameter("gripper_closed_position").value)
         self._gripper_speed = float(self.get_parameter("gripper_speed").value)
+        self._gripper_dir = 1.0 if self._gripper_open >= self._gripper_closed else -1.0
 
         # teleop.Teleop expects the natural_orientation in radians.
         natural_orientation_deg = list(self.get_parameter("natural_orientation").value)
@@ -229,10 +230,18 @@ class PhoneTeleopNode(Node):
                 if self._gripper_engaged:
                     self._gripper_position = self._gripper_closed
                 elif self._button_a_held:
-                    self._gripper_position = min(self._gripper_position + self._gripper_speed * dt, self._gripper_open)
-                elif self._button_b_held:
+                    lo = min(self._gripper_open, self._gripper_closed)
+                    hi = max(self._gripper_open, self._gripper_closed)
                     self._gripper_position = max(
-                        self._gripper_position - self._gripper_speed * dt, self._gripper_closed
+                        lo,
+                        min(hi, self._gripper_position + self._gripper_dir * self._gripper_speed * dt),
+                    )
+                elif self._button_b_held:
+                    lo = min(self._gripper_open, self._gripper_closed)
+                    hi = max(self._gripper_open, self._gripper_closed)
+                    self._gripper_position = max(
+                        lo,
+                        min(hi, self._gripper_position - self._gripper_dir * self._gripper_speed * dt),
                     )
                 gripper_value = self._gripper_position
 


### PR DESCRIPTION
## Description
This PR makes [pai_phone_teleop](https://github.com/ros-physical-ai/demos/blob/main/pai_phone_teleop/pai_phone_teleop/phone_teleop_node.py) robust to both gripper conventions:

- normal convention: `open_position > closed_position`
- inverted convention: `open_position < closed_position`

Previously, incremental open/close logic assumed a fixed ordering and could move in the wrong direction (or clamp incorrectly) when using inverted values.

## Why this is needed
Different robot/gripper integrations may define increasing position values as either opening or closing. This change removes that assumption and makes teleop behavior consistent across both setups.


## What changed
- Added a computed direction factor (_gripper_dir) from configured `gripper_open_position` and `gripper_closed_position` to support grippers where open/closed values are reversed.
- Updated A/B button gripper movement to use that direction.

## Validation
Verified logic for:
- standard ordering (open > closed)
- inverted ordering (open < closed)
- Confirmed button semantics (A=open, B=close) are preserved in both cases.