### PR TITLE
Replace start_zenoh with start-zenoh-router

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ pixi run build
 Launch the SO-ARM101 in Gazebo (start the Zenoh router first, in its own terminal):
 
 ```bash
-pixi run start_zenoh   # terminal 1
+pixi run start-zenoh-router   # terminal 1
 pixi run so-arm-gz     # terminal 2
 ```
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ pixi run build
 Launch the SO-ARM101 in Gazebo (start the Zenoh router first, in its own terminal):
 
 ```bash
-pixi run start-zenoh-router   # terminal 1
+pixi run zenoh-router  # terminal 1
 pixi run so-arm-gz     # terminal 2
 ```
 

--- a/docs/demos/end-to-end-pipeline.md
+++ b/docs/demos/end-to-end-pipeline.md
@@ -296,7 +296,7 @@ This section walks through the entire pipeline end-to-end using **Gazebo** and *
 ### Step 1 — Start the Zenoh Router
 
 ```bash
-pixi run start_zenoh
+pixi run start-zenoh-router
 ```
 
 ### Step 2 — Start Gazebo Simulation
@@ -357,7 +357,7 @@ Repeat (a)–(d) **3 times**.
 ```mermaid
 flowchart LR
     A["1. Start Zenoh
-    pixi run start_zenoh"] --> B["2. Start Gazebo
+    pixi run start-zenoh-router"] --> B["2. Start Gazebo
     pixi run so-arm-gz"]
     B --> C["3. Start Recorder
     ros2 launch rosetta ..."]

--- a/docs/demos/end-to-end-pipeline.md
+++ b/docs/demos/end-to-end-pipeline.md
@@ -296,7 +296,7 @@ This section walks through the entire pipeline end-to-end using **Gazebo** and *
 ### Step 1 — Start the Zenoh Router
 
 ```bash
-pixi run start-zenoh-router
+pixi run zenoh-router
 ```
 
 ### Step 2 — Start Gazebo Simulation
@@ -357,7 +357,7 @@ Repeat (a)–(d) **3 times**.
 ```mermaid
 flowchart LR
     A["1. Start Zenoh
-    pixi run start-zenoh-router"] --> B["2. Start Gazebo
+    pixi run zenoh-router"] --> B["2. Start Gazebo
     pixi run so-arm-gz"]
     B --> C["3. Start Recorder
     ros2 launch rosetta ..."]

--- a/docs/demos/pretrained-demo.md
+++ b/docs/demos/pretrained-demo.md
@@ -70,7 +70,7 @@ Follow the main [README](../../README.md) to set up the workspace (Pixi install 
 > running for the duration of your session:
 >
 > ```bash
-> pixi run start-zenoh-router
+> pixi run zenoh-router
 > ```
 >
 > See [Running the Robot](../running-the-robot.md) for details.
@@ -87,7 +87,7 @@ The fastest path to seeing the policy in action is to skip the rosbags and datas
 ```mermaid
 flowchart LR
     A["1. Start Zenoh
-    pixi run start-zenoh-router"] --> B["2. Start Gazebo
+    pixi run zenoh-router"] --> B["2. Start Gazebo
     pixi run so-arm-gz"]
     B --> C["3. Launch Rosetta Client
     pretrained_name_or_path:=francocipollone/rospai_act_sim_arm101_place_cubes_on_tray"]

--- a/docs/demos/pretrained-demo.md
+++ b/docs/demos/pretrained-demo.md
@@ -70,7 +70,7 @@ Follow the main [README](../../README.md) to set up the workspace (Pixi install 
 > running for the duration of your session:
 >
 > ```bash
-> pixi run start_zenoh
+> pixi run start-zenoh-router
 > ```
 >
 > See [Running the Robot](../running-the-robot.md) for details.
@@ -87,7 +87,7 @@ The fastest path to seeing the policy in action is to skip the rosbags and datas
 ```mermaid
 flowchart LR
     A["1. Start Zenoh
-    pixi run start_zenoh"] --> B["2. Start Gazebo
+    pixi run start-zenoh-router"] --> B["2. Start Gazebo
     pixi run so-arm-gz"]
     B --> C["3. Launch Rosetta Client
     pretrained_name_or_path:=francocipollone/rospai_act_sim_arm101_place_cubes_on_tray"]

--- a/docs/development.md
+++ b/docs/development.md
@@ -62,7 +62,7 @@ Before running any ROS 2 commands, start the Zenoh router in a separate terminal
 Terminal 1 (start Zenoh router):
 
 ```bash
-pixi run start_zenoh
+pixi run start-zenoh-router
 ```
 
 Terminal 2 (launch Gazebo simulation):
@@ -91,7 +91,7 @@ You can run commands (e.g., `colcon build`, Python scripts) directly.
 This is useful for interactive debugging, testing, and running multiple commands.
 
 Note: When running ROS 2 commands manually in the shell, ensure the Zenoh router is running.
-Start it in a separate terminal using `pixi run start_zenoh`.
+Start it in a separate terminal using `pixi run start-zenoh-router`.
 
 Additional resources for using Pixi can be found at this [blog](https://jafarabdi.github.io/blog/2025/ros2-pixi-dev/).
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -62,7 +62,7 @@ Before running any ROS 2 commands, start the Zenoh router in a separate terminal
 Terminal 1 (start Zenoh router):
 
 ```bash
-pixi run start-zenoh-router
+pixi run zenoh-router
 ```
 
 Terminal 2 (launch Gazebo simulation):
@@ -91,7 +91,7 @@ You can run commands (e.g., `colcon build`, Python scripts) directly.
 This is useful for interactive debugging, testing, and running multiple commands.
 
 Note: When running ROS 2 commands manually in the shell, ensure the Zenoh router is running.
-Start it in a separate terminal using `pixi run start-zenoh-router`.
+Start it in a separate terminal using `pixi run zenoh-router`.
 
 Additional resources for using Pixi can be found at this [blog](https://jafarabdi.github.io/blog/2025/ros2-pixi-dev/).
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -60,4 +60,4 @@ source ~/ws_pai/install/setup.bash
 > This project uses [rmw_zenoh](https://github.com/ros2/rmw_zenoh) as the default ROS 2 middleware.
 > When using Pixi, this is configured automatically. For manual installs, install it via
 > `sudo apt install ros-kilted-rmw-zenoh-cpp` and `export RMW_IMPLEMENTATION=rmw_zenoh_cpp`.
-> Ensure the Zenoh router is running: `ros2 run rmw_zenoh_cpp rmw_zenohd` (or `pixi run start-zenoh-router`).
+> Ensure the Zenoh router is running: `ros2 run rmw_zenoh_cpp rmw_zenohd` (or `pixi run zenoh-router`).

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -60,4 +60,4 @@ source ~/ws_pai/install/setup.bash
 > This project uses [rmw_zenoh](https://github.com/ros2/rmw_zenoh) as the default ROS 2 middleware.
 > When using Pixi, this is configured automatically. For manual installs, install it via
 > `sudo apt install ros-kilted-rmw-zenoh-cpp` and `export RMW_IMPLEMENTATION=rmw_zenoh_cpp`.
-> Ensure the Zenoh router is running: `ros2 run rmw_zenoh_cpp rmw_zenohd` (or `pixi run start_zenoh`).
+> Ensure the Zenoh router is running: `ros2 run rmw_zenoh_cpp rmw_zenohd` (or `pixi run start-zenoh-router`).

--- a/docs/running-the-robot.md
+++ b/docs/running-the-robot.md
@@ -8,7 +8,7 @@ This guide covers launching the SO-ARM101 in simulation (Gazebo or MuJoCo) or on
 > running for the duration of your session:
 >
 > ```bash
-> pixi run start_zenoh
+> pixi run start-zenoh-router
 > ```
 >
 > Then open a second terminal for the launch commands below. When using a manual

--- a/docs/running-the-robot.md
+++ b/docs/running-the-robot.md
@@ -8,7 +8,7 @@ This guide covers launching the SO-ARM101 in simulation (Gazebo or MuJoCo) or on
 > running for the duration of your session:
 >
 > ```bash
-> pixi run start-zenoh-router
+> pixi run zenoh-router
 > ```
 >
 > Then open a second terminal for the launch commands below. When using a manual

--- a/pai_data_collection/README.md
+++ b/pai_data_collection/README.md
@@ -26,7 +26,7 @@ Recording uses rosetta's `episode_recorder_launch.py` directly.
 1. Run zenoh router on a separate terminal:
 
 ```bash
-pixi run start_zenoh # ros2 run rmw_zenoh_cpp rmw_zenohd
+pixi run start-zenoh-router # ros2 run rmw_zenoh_cpp rmw_zenohd
 ```
 
 2. Start simulation:
@@ -94,7 +94,7 @@ This will save a rosbag that corresponds to that episode.
 ```mermaid
 flowchart LR
     A["1. Start Zenoh Router
-    pixi run start_zenoh"] --> B["2. Start Simulation
+    pixi run start-zenoh-router"] --> B["2. Start Simulation
     pixi run so-arm-gz"]
     B --> C["3. Start Episode Recorder
     ros2 launch rosetta episode_recorder_launch.py ..."]
@@ -116,7 +116,7 @@ flowchart LR
 
 Use MuJoCo simulation with the same `so_arm101.yaml` contract.
 
-1. Start zenoh router: `pixi run start_zenoh`
+1. Start zenoh router: `pixi run start-zenoh-router`
 2. Start MuJoCo + camera relay: `pixi run so-arm-mujoco`
 3. Start rosetta recorder: `pixi run rosetta-record-mujoco`
 4. Start keyboard controller (new terminal): `ros2 run rosetta episode_keyboard_node`

--- a/pai_data_collection/README.md
+++ b/pai_data_collection/README.md
@@ -26,7 +26,7 @@ Recording uses rosetta's `episode_recorder_launch.py` directly.
 1. Run zenoh router on a separate terminal:
 
 ```bash
-pixi run start-zenoh-router # ros2 run rmw_zenoh_cpp rmw_zenohd
+pixi run zenoh-router # ros2 run rmw_zenoh_cpp rmw_zenohd
 ```
 
 2. Start simulation:
@@ -94,7 +94,7 @@ This will save a rosbag that corresponds to that episode.
 ```mermaid
 flowchart LR
     A["1. Start Zenoh Router
-    pixi run start-zenoh-router"] --> B["2. Start Simulation
+    pixi run zenoh-router"] --> B["2. Start Simulation
     pixi run so-arm-gz"]
     B --> C["3. Start Episode Recorder
     ros2 launch rosetta episode_recorder_launch.py ..."]
@@ -116,7 +116,7 @@ flowchart LR
 
 Use MuJoCo simulation with the same `so_arm101.yaml` contract.
 
-1. Start zenoh router: `pixi run start-zenoh-router`
+1. Start zenoh router: `pixi run zenoh-router`
 2. Start MuJoCo + camera relay: `pixi run so-arm-mujoco`
 3. Start rosetta recorder: `pixi run rosetta-record-mujoco`
 4. Start keyboard controller (new terminal): `ros2 run rosetta episode_keyboard_node`

--- a/pai_rviz_teleop/README.md
+++ b/pai_rviz_teleop/README.md
@@ -45,7 +45,7 @@ The Zenoh router must be running first (see the repository README). Then launch
 your hardware/sim bringup and the SO-ARM101 demo (which also starts the IK servo):
 
 ```bash
-pixi run start_zenoh        # terminal 1
+pixi run start-zenoh-router        # terminal 1
 pixi run so-arm-mujoco      # terminal 2 (MuJoCo + controllers; or another bringup)
 pixi run so-arm-rviz-ik     # terminal 3 (IK servo + marker adapter)
 ```

--- a/pai_rviz_teleop/README.md
+++ b/pai_rviz_teleop/README.md
@@ -45,7 +45,7 @@ The Zenoh router must be running first (see the repository README). Then launch
 your hardware/sim bringup and the SO-ARM101 demo (which also starts the IK servo):
 
 ```bash
-pixi run start-zenoh-router        # terminal 1
+pixi run zenoh-router       # terminal 1
 pixi run so-arm-mujoco      # terminal 2 (MuJoCo + controllers; or another bringup)
 pixi run so-arm-rviz-ik     # terminal 3 (IK servo + marker adapter)
 ```

--- a/pixi.toml
+++ b/pixi.toml
@@ -28,7 +28,7 @@ build = { cmd = ["colcon", "build", "--cmake-args", "-DCMAKE_BUILD_TYPE=Release"
 clean = { cmd = "rm -rf build install log" }
 
 # Run Demos
-start-zenoh-router = { cmd = [
+zenoh-router = { cmd = [
   "ros2",
   "run",
   "rmw_zenoh_cpp",

--- a/pixi.toml
+++ b/pixi.toml
@@ -28,7 +28,7 @@ build = { cmd = ["colcon", "build", "--cmake-args", "-DCMAKE_BUILD_TYPE=Release"
 clean = { cmd = "rm -rf build install log" }
 
 # Run Demos
-start_zenoh = { cmd = [
+start-zenoh-router = { cmd = [
   "ros2",
   "run",
   "rmw_zenoh_cpp",


### PR DESCRIPTION
This PR replaces `start_zenoh` with `start-zenoh-router.`
All the other pixi tasks are `-` separated.
`start-zenoh-router` also more accurately describes the outcome. 