### PR TITLE
Update mujoco_ros2_control version

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,7 @@ Requires Linux and [Pixi](https://pixi.sh/latest/installation/) (which bundles R
 git clone https://github.com/ros-physical-ai/demos
 cd demos
 pixi install
-pixi run install-source-deps  # External dependencies from source
-pixi run install-ml-deps   # PyTorch + LeRobot (auto-detects GPU)
+pixi run install-deps
 pixi run build
 ```
 

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ Requires Linux and [Pixi](https://pixi.sh/latest/installation/) (which bundles R
 ```bash
 git clone https://github.com/ros-physical-ai/demos
 cd demos
-vcs import external < pai.repos --recursive
 pixi install
+pixi run install-source-deps  # External dependencies from source
 pixi run install-ml-deps   # PyTorch + LeRobot (auto-detects GPU)
 pixi run build
 ```

--- a/pai.repos
+++ b/pai.repos
@@ -7,10 +7,14 @@ repositories:
     type: git
     url: https://github.com/ros-physical-ai/feetech_ros2_driver.git
     version: 18aed7fb26d3e2b4c0b47762f39d8698b7032422
+  mujoco_vendor:
+    type: git
+    url: https://github.com/pal-robotics/mujoco_vendor.git
+    version: 23c52ca18ceb1067c68a42fd5afc81938ce2713c
   mujoco_ros2_control:
     type: git
     url: https://github.com/ros-controls/mujoco_ros2_control.git
-    version: cd4340cc3878142def1f88845518f2b29647c7c2
+    version: 7f0aa57c19057f141cb2b74c875cca0064109c0e
   rosetta:
     type: git
     url: https://github.com/iblnkn/rosetta.git

--- a/pai_bringup/config/mujoco/mujoco_pid.yaml
+++ b/pai_bringup/config/mujoco/mujoco_pid.yaml
@@ -1,0 +1,58 @@
+# PID gains for the SO-ARM101 MuJoCo hardware interface.
+#
+# Gains are only consulted for non-position MuJoCo actuators (e.g., <motor>).
+# The values below mirror the sts3215 position actuator class in
+# mjcf/so_arm101.xml.xacro (kp=998.22, kv=2.731, forcerange ±3.35) so that
+# swapping the actuators to <motor> preserves the same closed-loop behavior.
+/**:
+  ros__parameters:
+    pid_gains:
+      position:
+        shoulder_pan_joint:
+          p: 998.22
+          i: 0.0
+          d: 2.731
+          u_clamp_max: 3.35
+          u_clamp_min: -3.35
+          i_clamp_max: 1.0
+          i_clamp_min: -1.0
+        shoulder_lift_joint:
+          p: 998.22
+          i: 0.0
+          d: 2.731
+          u_clamp_max: 3.35
+          u_clamp_min: -3.35
+          i_clamp_max: 1.0
+          i_clamp_min: -1.0
+        elbow_flex_joint:
+          p: 998.22
+          i: 0.0
+          d: 2.731
+          u_clamp_max: 3.35
+          u_clamp_min: -3.35
+          i_clamp_max: 1.0
+          i_clamp_min: -1.0
+        wrist_flex_joint:
+          p: 998.22
+          i: 0.0
+          d: 2.731
+          u_clamp_max: 3.35
+          u_clamp_min: -3.35
+          i_clamp_max: 1.0
+          i_clamp_min: -1.0
+        wrist_roll_joint:
+          p: 998.22
+          i: 0.0
+          d: 2.731
+          u_clamp_max: 3.35
+          u_clamp_min: -3.35
+          i_clamp_max: 1.0
+          i_clamp_min: -1.0
+        gripper_joint:
+          p: 998.22
+          i: 0.0
+          d: 2.731
+          u_clamp_max: 3.35
+          u_clamp_min: -3.35
+          i_clamp_max: 1.0
+          i_clamp_min: -1.0

--- a/pai_bringup/config/mujoco/mujoco_ros2_control_plugins.yaml
+++ b/pai_bringup/config/mujoco/mujoco_ros2_control_plugins.yaml
@@ -1,0 +1,18 @@
+/**:
+  ros__parameters:
+    mujoco_plugins:
+      mujoco_camera_plugin:
+        type: "mujoco_ros2_control_plugins/CameraPlugin"
+        camera_publish_rate: 10.0
+        wrist_camera:
+          policy: streaming
+          frame_name: wrist_camera_link
+          info_topic: /wrist_camera/camera_info
+          image_topic: /wrist_camera/image_raw
+          depth_topic: /wrist_camera/depth
+        static_camera:
+          policy: streaming
+          frame_name: static_camera_link
+          info_topic: /static_camera/camera_info
+          image_topic: /static_camera/image_raw
+          depth_topic: /static_camera/depth

--- a/pai_bringup/launch/so_arm_mujoco_bringup.launch.py
+++ b/pai_bringup/launch/so_arm_mujoco_bringup.launch.py
@@ -118,6 +118,11 @@ def launch_setup(context, *args, **kwargs):
     ).perform(context)
     controller_parameters = ParameterFile(controllers_file_str, allow_substs=True)
 
+    mujoco_plugins_file = PathJoinSubstitution(
+        [FindPackageShare("pai_bringup"), "config", "mujoco", "mujoco_ros2_control_plugins.yaml"]
+    )
+    mujoco_plugins_parameters = ParameterFile(mujoco_plugins_file, allow_substs=True)
+
     description_file = PathJoinSubstitution([FindPackageShare("pai_bringup"), "urdf", "so_arm101_mujoco.urdf.xacro"])
 
     control_node = Node(
@@ -127,6 +132,7 @@ def launch_setup(context, *args, **kwargs):
         parameters=[
             {"use_sim_time": True},
             controller_parameters,
+            mujoco_plugins_parameters,
         ],
         # The controller manager takes the URDF from ~/robot_description, not
         # from a robot_description parameter.

--- a/pai_bringup/urdf/so_arm101_mujoco.urdf.xacro
+++ b/pai_bringup/urdf/so_arm101_mujoco.urdf.xacro
@@ -29,23 +29,17 @@
       <plugin>mujoco_ros2_control/MujocoSystemInterface</plugin>
       <param name="mujoco_model">$(arg mujoco_model)</param>
       <param name="sim_speed_factor">1.0</param>
-      <param name="camera_publish_rate">10.0</param>
+      <param name="pids_config_file">$(find pai_bringup)/config/mujoco/mujoco_pid.yaml</param>
     </hardware>
 
     <joint name="$(arg prefix)shoulder_pan_joint">
       <param name="initial_position">0.0</param>
-      <param name="id">1</param>
-      <param name="p_cofficient">8</param>
-      <param name="offset">2048</param>
       <command_interface name="position" />
       <state_interface name="position" />
       <state_interface name="velocity" />
     </joint>
 
     <joint name="$(arg prefix)shoulder_lift_joint">
-      <param name="id">2</param>
-      <param name="p_cofficient">16</param>
-      <param name="offset">2125</param>
       <param name="initial_position">0.0</param>
       <command_interface name="position" />
       <state_interface name="position" />
@@ -53,9 +47,6 @@
     </joint>
 
     <joint name="$(arg prefix)elbow_flex_joint">
-      <param name="id">3</param>
-      <param name="offset">2080</param>
-      <param name="p_cofficient">16</param>
       <param name="initial_position">0.0</param>
       <command_interface name="position" />
       <state_interface name="position" />
@@ -63,9 +54,6 @@
     </joint>
 
     <joint name="$(arg prefix)wrist_flex_joint">
-      <param name="id">4</param>
-      <param name="offset">3110</param>
-      <param name="p_cofficient">16</param>
       <param name="initial_position">0.0</param>
       <command_interface name="position" />
       <state_interface name="position" />
@@ -73,9 +61,6 @@
     </joint>
 
     <joint name="$(arg prefix)wrist_roll_joint">
-      <param name="id">5</param>
-      <param name="offset">1024</param>
-      <param name="p_cofficient">16</param>
       <param name="initial_position">0.0</param>
       <command_interface name="position" />
       <state_interface name="position" />
@@ -83,30 +68,11 @@
     </joint>
 
     <joint name="$(arg prefix)gripper_joint">
-      <param name="id">6</param>
-      <param name="offset">2070</param>
-      <param name="p_cofficient">16</param>
       <param name="initial_position">0.0</param>
       <command_interface name="position" />
       <state_interface name="position" />
       <state_interface name="velocity" />
     </joint>
-
-    <!-- Wrist camera (MuJoCo camera name must match sensor name) -->
-    <sensor name="wrist_camera">
-      <param name="frame_name">wrist_camera_link</param>
-      <param name="info_topic">/wrist_camera/camera_info</param>
-      <param name="image_topic">/wrist_camera/image_raw</param>
-      <param name="depth_topic">/wrist_camera/depth</param>
-    </sensor>
-
-    <!-- Static camera -->
-    <sensor name="static_camera">
-      <param name="frame_name">static_camera_link</param>
-      <param name="info_topic">/static_camera/camera_info</param>
-      <param name="image_topic">/static_camera/image_raw</param>
-      <param name="depth_topic">/static_camera/depth</param>
-    </sensor>
   </ros2_control>
 
 </robot>

--- a/pixi.toml
+++ b/pixi.toml
@@ -21,11 +21,12 @@ CMAKE_INSTALL_MODE = "COPY"
 # Lint
 lint = { cmd = "pre-commit run --all-files" }
 
+# Install dependencies
 # Bring external repos via vcstool
 install-source-deps = { cmd = "vcs import external --recursive < pai.repos" }
-
 # Longer uv download timeout (PyTorch wheels are huge).
 install-ml-deps = { cmd = "bash scripts/install_ml_deps.sh", env = { UV_HTTP_TIMEOUT = "600" } }
+install-deps = { depends-on = ["install-source-deps", "install-ml-deps"] }
 
 # Build
 # cmake-args live in colcon_defaults.yaml (read from the workspace root).

--- a/pixi.toml
+++ b/pixi.toml
@@ -21,6 +21,9 @@ CMAKE_INSTALL_MODE = "COPY"
 # Lint
 lint = { cmd = "pre-commit run --all-files" }
 
+# Bring external repos via vcstool
+install-source-deps = { cmd = "vcs import external --recursive < pai.repos" }
+
 # Longer uv download timeout (PyTorch wheels are huge).
 install-ml-deps = { cmd = "bash scripts/install_ml_deps.sh", env = { UV_HTTP_TIMEOUT = "600" } }
 


### PR DESCRIPTION
I realized we were using a pretty old version of `mujoco_ros2_control`

Since then, they have added some performance improvements and quality of life features... and also plugins. It's always plugins.

Tested by bringing up the mujoco sim and using RViz teleop.

Also as an anecdote, it appears on `main` I can only get cameras at 6.8 Hz, but updating to this branch I'm at 8 Hz, so that's a nice little boost.